### PR TITLE
docs: Replaced weierophinney/hal with zendframework/zend-expressive-hal

### DIFF
--- a/docs/book/intro.md
+++ b/docs/book/intro.md
@@ -46,7 +46,7 @@ relational links, from PHP objects.**
 Use Composer:
 
 ```bash
-$ composer require weierophinney/hal
+$ composer require zendframework/zend-expressive-hal
 ```
 
 If you are adding this to an Expressive application, and have the

--- a/docs/book/links-and-resources.md
+++ b/docs/book/links-and-resources.md
@@ -13,7 +13,7 @@ The basic building blocks of this component are links and resources:
 
 > ### PSR-13
 > 
-> weierophinney/hal implements [PSR-13](http://www.php-fig.org/psr/psr-13/),
+> zendframework/zend-expressive-hal implements [PSR-13](http://www.php-fig.org/psr/psr-13/),
 > which provides interfaces for relational links and collections of relational
 > links. `Zend\Expressive\Hal\Link` implements `Psr\Link\EvolvableLinkInterface`, and
 > `Zend\Expressive\Hal\HalResource` implements `Psr\Link\EvolvableLinkProviderInterface`.


### PR DESCRIPTION
Renamed the repo/package in the docs after repo change.