### PR TITLE
Update wrong package name in docs

### DIFF
--- a/docs/book/intro.md
+++ b/docs/book/intro.md
@@ -46,7 +46,7 @@ relational links, from PHP objects.**
 Use Composer:
 
 ```bash
-$ composer require weierophinney/hal
+$ composer require zendframework/zend-expressive-hal
 ```
 
 If you are adding this to an Expressive application, and have the


### PR DESCRIPTION
Update wrong legacy package name (has since moved over to the zendframework namespace)

Provide a narrative description of what you are trying to accomplish:

- Are you fixing a bug? no
  - Detail how the bug is invoked currently.
  - Detail the original, incorrect behavior.
  - Detail the new, expected behavior.

- Are you creating a new feature? no
  - Why is the new feature needed? What purpose does it serve?
  - How will users use the new feature?

- Is this related to quality assurance? no
  - Detail why the changes are necessary.

- Is this related to documentation?
  - Is it a typographical and/or grammatical fix? yes
  - Is it new documentation? no
