### PR TITLE
Hotfix - exceptions

### DIFF
--- a/src/Exception/InvalidObjectException.php
+++ b/src/Exception/InvalidObjectException.php
@@ -8,6 +8,7 @@
 namespace Zend\Expressive\Hal\Exception;
 
 use InvalidArgumentException;
+use Zend\Expressive\Hal\HalResource;
 
 class InvalidObjectException extends InvalidArgumentException implements Exception
 {

--- a/src/Exception/InvalidResourceValueException.php
+++ b/src/Exception/InvalidResourceValueException.php
@@ -8,6 +8,7 @@
 namespace Zend\Expressive\Hal\Exception;
 
 use RuntimeException;
+use Zend\Expressive\Hal\HalResource;
 
 class InvalidResourceValueException extends RuntimeException implements Exception
 {

--- a/src/Exception/InvalidStrategyException.php
+++ b/src/Exception/InvalidStrategyException.php
@@ -8,6 +8,7 @@
 namespace Zend\Expressive\Hal\Exception;
 
 use InvalidArgumentException;
+use Zend\Expressive\Hal\ResourceGenerator\Strategy;
 
 class InvalidStrategyException extends InvalidArgumentException implements Exception
 {
@@ -16,7 +17,7 @@ class InvalidStrategyException extends InvalidArgumentException implements Excep
         return new self(sprintf(
             'Invalid strategy "%s"; does not exist, or does not implement %s',
             $strategy,
-            ResourceGenerator\Strategy::class
+            Strategy::class
         ));
     }
 
@@ -28,7 +29,7 @@ class InvalidStrategyException extends InvalidArgumentException implements Excep
         return new self(sprintf(
             'Invalid strategy of type "%s"; does not implement %s',
             is_object($strategy) ? get_class($strategy) : gettype($strategy),
-            ResourceGenerator\Strategy::class
+            Strategy::class
         ));
     }
 }

--- a/src/Exception/UnknownMetadataTypeException.php
+++ b/src/Exception/UnknownMetadataTypeException.php
@@ -8,10 +8,11 @@
 namespace Zend\Expressive\Hal\Exception;
 
 use RuntimeException;
+use Zend\Expressive\Hal\Metadata\AbstractMetadata;
 
 class UnknownMetadataTypeException extends RuntimeException implements Exception
 {
-    public static function forMetadata(Metadata\AbstractMetadata $metadata) : self
+    public static function forMetadata(AbstractMetadata $metadata) : self
     {
         return new self(sprintf(
             'Encountered unknown metadata type %s; no strategy available for creating resource from this metadata',
@@ -24,7 +25,7 @@ class UnknownMetadataTypeException extends RuntimeException implements Exception
         return new self(sprintf(
             'Invalid metadata type "%s"; does not exist, or does not extend %s',
             $metadata,
-            Metadata\AbstractMetadata::class
+            AbstractMetadata::class
         ));
     }
 }

--- a/src/Metadata/Exception/InvalidConfigException.php
+++ b/src/Metadata/Exception/InvalidConfigException.php
@@ -7,8 +7,10 @@
 
 namespace Zend\Expressive\Hal\Metadata\Exception;
 
-use Zend\Expressive\Hal\Metadata\AbstractMetadata;
 use RuntimeException;
+use Zend\Expressive\Hal\Metadata\AbstractMetadata;
+use Zend\Expressive\Hal\Metadata\MetadataMap;
+use Zend\Expressive\Hal\Metadata\MetadataMapFactory;
 
 class InvalidConfigException extends RuntimeException implements Exception
 {

--- a/src/ResourceGenerator/RouteBasedCollectionStrategy.php
+++ b/src/ResourceGenerator/RouteBasedCollectionStrategy.php
@@ -28,7 +28,7 @@ class RouteBasedCollectionStrategy implements Strategy
             throw Exception\UnexpectedMetadataTypeException::forMetadata(
                 $metadata,
                 self::class,
-                Metadata\RouteBasedCollectionMetadata
+                Metadata\RouteBasedCollectionMetadata::class
             );
         }
 

--- a/src/ResourceGenerator/RouteBasedResourceStrategy.php
+++ b/src/ResourceGenerator/RouteBasedResourceStrategy.php
@@ -27,7 +27,7 @@ class RouteBasedResourceStrategy implements Strategy
             throw Exception\UnexpectedMetadataTypeException::forMetadata(
                 $metadata,
                 self::class,
-                Metadata\RouteBasedResourceMetadata
+                Metadata\RouteBasedResourceMetadata::class
             );
         }
 

--- a/src/ResourceGenerator/UrlBasedCollectionStrategy.php
+++ b/src/ResourceGenerator/UrlBasedCollectionStrategy.php
@@ -28,7 +28,7 @@ class UrlBasedCollectionStrategy implements Strategy
             throw Exception\UnexpectedMetadataTypeException::forMetadata(
                 $metadata,
                 self::class,
-                Metadata\UrlBasedCollectionMetadata
+                Metadata\UrlBasedCollectionMetadata::class
             );
         }
 

--- a/src/ResourceGenerator/UrlBasedResourceStrategy.php
+++ b/src/ResourceGenerator/UrlBasedResourceStrategy.php
@@ -27,7 +27,7 @@ class UrlBasedResourceStrategy implements Strategy
             throw Exception\UnexpectedMetadataTypeException::forMetadata(
                 $metadata,
                 self::class,
-                Metadata\UrlBasedResourceMetadata
+                Metadata\UrlBasedResourceMetadata::class
             );
         }
 

--- a/test/ResourceGeneratorTest.php
+++ b/test/ResourceGeneratorTest.php
@@ -396,8 +396,10 @@ class ResourceGeneratorTest extends TestCase
     /**
      * @dataProvider strategyCollection
      */
-    public function testNotTraversableInstanceForCollectionStrategy(ResourceGenerator\Strategy $strategy, string $metadata)
-    {
+    public function testNotTraversableInstanceForCollectionStrategy(
+        ResourceGenerator\Strategy $strategy,
+        string $metadata
+    ) {
         $collectionMetadata = new $metadata(
             TestAsset\FooBar::class,
             'foo-bar',

--- a/test/ResourceGeneratorTest.php
+++ b/test/ResourceGeneratorTest.php
@@ -392,4 +392,25 @@ class ResourceGeneratorTest extends TestCase
         $this->expectExceptionMessage('Unexpected metadata of type');
         $this->generator->fromObject($instance, $this->request->reveal());
     }
+
+    /**
+     * @dataProvider strategyCollection
+     */
+    public function testNotTraversableInstanceForCollectionStrategy(ResourceGenerator\Strategy $strategy, string $metadata)
+    {
+        $collectionMetadata = new $metadata(
+            TestAsset\FooBar::class,
+            'foo-bar',
+            '/api/foo'
+        );
+
+        $this->metadataMap->has(TestAsset\FooBar::class)->willReturn(true);
+        $this->metadataMap->get(TestAsset\FooBar::class)->willReturn($collectionMetadata);
+
+        $instance = new TestAsset\FooBar();
+
+        $this->expectException(ResourceGenerator\Exception\InvalidCollectionException::class);
+        $this->expectExceptionMessage('not a Traversable');
+        $this->generator->fromObject($instance, $this->request->reveal());
+    }
 }


### PR DESCRIPTION
There was missing `::class` on exception types. Factory expects `string`.
Tests added.

ping @weierophinney 