### PR TITLE
Disable code coverage on PHP 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ matrix:
     - php: 7.2
       env:
         - DEPS=locked
-        - TEST_COVERAGE=true
     - php: 7.2
       env:
         - DEPS=latest


### PR DESCRIPTION
Coverage is generated on PHP 7.1 and it is no need to generate it again on PHP 7.2