### PR TITLE
Added nightly build in Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,18 @@ matrix:
     - php: 7.2
       env:
         - DEPS=latest
+    - php: nightly
+      env:
+        - DEPS=lowest
+    - php: nightly
+      env:
+        - DEPS=locked
+    - php: nightly
+      env:
+        - DEPS=latest
   allow_failures:
     - php: 7.2
+    - php: nightly
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' && $TRAVIS_PHP_VERSION =~ ^7.1 ]]; then phpenv config-rm xdebug.ini || return 0 ; fi


### PR DESCRIPTION
"nightly" points now to PHP 7.3-dev

... or it's too early to add nightly (PHP 7.3-dev) to the matrix?