### PR TITLE
Fix bad return type method: RouteBasedResourceMetadata::setRouteParams() (issue #14)

### DIFF
--- a/src/Metadata/RouteBasedResourceMetadata.php
+++ b/src/Metadata/RouteBasedResourceMetadata.php
@@ -57,7 +57,7 @@ class RouteBasedResourceMetadata extends AbstractResourceMetadata
         return $this->routeParams;
     }
 
-    public function setRouteParams(array $routeParams) : array
+    public function setRouteParams(array $routeParams) : void
     {
         $this->routeParams = $routeParams;
     }


### PR DESCRIPTION
Bad return type for [Zend\Expressive\Hal\Metadata\RouteBasedResourceMetadata::setRouteParams()](https://github.com/zendframework/zend-expressive-hal/blob/fe9641afce9917958136307057300c5ba130ba83/src/Metadata/RouteBasedResourceMetadata.php#L60) method.

### Code to reproduce the issue

```php
$metadataMap  = $this->resourceGenerator->getMetadataMap();
$metadata     = $metadataMap->get(Item::class);
$routesParams = array_merge($metadata->getRouteParams(), ['categoryId' => $categoryId]);
$metadata->setRouteParams($routesParams);
```

### Expected results

No error

### Actual results

throws TypeError : 

```bash
Return value of Zend\\Expressive\\Hal\\Metadata\\RouteBasedResourceMetadata::setRouteParams() must be of the type array, none returned
```