### PR TITLE
Complete renaming of interfaces, traits

### DIFF
--- a/docs/book/factories.md
+++ b/docs/book/factories.md
@@ -44,12 +44,12 @@ provide services for `Psr\Http\Message\ResponseInterface` and
     - `Zend\Expressive\Helper\ServerUrlHelper` service (optional; if not provided,
       URIs will be generated without authority information)
 
-## Zend\Expressive\Hal\LinkGenerator\UrlGenerator
+## Zend\Expressive\Hal\LinkGenerator\UrlGeneratorInterface
 
-- Registered as service: `Zend\Expressive\Hal\LinkGenerator\UrlGenerator`
+- Registered as service: `Zend\Expressive\Hal\LinkGenerator\UrlGeneratorInterface`
 - Aliased to service: `Zend\Expressive\Hal\LinkGenerator\ExpressiveUrlGenerator`
 
-You can either define an alternate alias, or map the `UrlGenerator` service
+You can either define an alternate alias, or map the `UrlGeneratorInterface` service
 directly to a factory that will return a valid instance.
 
 ## Zend\Expressive\Hal\Metadata\MetadataMapFactory

--- a/docs/book/intro.md
+++ b/docs/book/intro.md
@@ -174,8 +174,10 @@ class BookAction implements MiddlewareInterface
 {
     /** @var JsonRenderer */
     private $renderer;
+
     /** @var Repository */
     private $repository;
+
     public function __construct(
         Repository $repository,
         JsonRenderer $renderer
@@ -183,6 +185,7 @@ class BookAction implements MiddlewareInterface
         $this->repository = $repository;
         $this->renderer = $renderer;
     }
+
     public function process(ServerRequestInterface $request, DelegateInterface $delegate)
     {
         $id = $request->getAttribute('id', false);

--- a/docs/book/links-and-resources.md
+++ b/docs/book/links-and-resources.md
@@ -78,15 +78,15 @@ specifications. `Link` expects only a string URI, however; how can you prevent
 hard-coding that URI?
 
 This component provides a tool for that: `Zend\Expressive\Hal\LinkGenerator`.
-This class composes a `Zend\Expressive\Hal\LinkGenerator\UrlGenerator` instance,
-which defines the following:
+This class composes a `Zend\Expressive\Hal\LinkGenerator\UrlGeneratorInterface`
+instance, which defines the following:
 
 ```php
 namespace Zend\Expressive\Hal\LinkGenerator;
 
 use Psr\Http\Message\ServerRequestInterface;
 
-interface UrlGenerator
+interface UrlGeneratorInterface
 {
     /**
      * Generate a URL for use as the HREF of a link.

--- a/docs/book/representations.md
+++ b/docs/book/representations.md
@@ -10,14 +10,14 @@ more detail.
 
 ## Renderers
 
-All renderers implement `Zend\Expressive\Hal\Renderer\Renderer`:
+All renderers implement `Zend\Expressive\Hal\Renderer\RendererInterface`:
 
 ```php
 namespace Zend\Expressive\Hal\Renderer;
 
 use Zend\Expressive\Hal\HalResource;
 
-interface Renderer
+interface RendererInterface
 {
     public function render(HalResource $resource) : string;
 }

--- a/docs/book/resource-generator.md
+++ b/docs/book/resource-generator.md
@@ -152,8 +152,8 @@ URIs for `Link` instances.)
 
 ### Customizing resource generation
 
-The `ResourceGenerator` allows composing `Zend\Expressive\Hal\ResourceGenerator\Strategy`
-instances. The `Strategy` interface defines the following:
+The `ResourceGenerator` allows composing `Zend\Expressive\Hal\ResourceGenerator\StrategyInterface`
+instances. The `StrategyInterface` defines the following:
 
 ```php
 namespace Zend\Expressive\Hal\ResourceGenerator;
@@ -163,7 +163,7 @@ use Zend\Expressive\Hal\HalResource;
 use Zend\Expressive\Hal\Metadata;
 use Zend\Expressive\Hal\ResourceGenerator;
 
-interface Strategy
+interface StrategyInterface
 {
     /**
      * @param object $instance Instance from which to create Resource.
@@ -194,6 +194,6 @@ If a strategy already is mapped for the given metadata type, this method will
 override it.
 
 To facilitate common operations, this library provides two traits,
-`Zend\Expressive\Hal\ResourceGenerator\ExtractCollection` and
-`Zend\Expressive\Hal\ResourceGenerator\ExtractInstance`; inspect these if you
+`Zend\Expressive\Hal\ResourceGenerator\ExtractCollectionTrait` and
+`Zend\Expressive\Hal\ResourceGenerator\ExtractInstanceTrait`; inspect these if you
 decide to write your own strategies.

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -20,7 +20,7 @@ class ConfigProvider
     {
         return [
             'aliases' => [
-                LinkGenerator\UrlGenerator::class => LinkGenerator\ExpressiveUrlGenerator::class,
+                LinkGenerator\UrlGeneratorInterface::class => LinkGenerator\ExpressiveUrlGenerator::class,
             ],
             'factories' => [
                 HalResponseFactory::class => HalResponseFactoryFactory::class,

--- a/src/Exception/InvalidStrategyException.php
+++ b/src/Exception/InvalidStrategyException.php
@@ -8,7 +8,7 @@
 namespace Zend\Expressive\Hal\Exception;
 
 use InvalidArgumentException;
-use Zend\Expressive\Hal\ResourceGenerator\Strategy;
+use Zend\Expressive\Hal\ResourceGenerator\StrategyInterface;
 
 class InvalidStrategyException extends InvalidArgumentException implements ExceptionInterface
 {
@@ -17,7 +17,7 @@ class InvalidStrategyException extends InvalidArgumentException implements Excep
         return new self(sprintf(
             'Invalid strategy "%s"; does not exist, or does not implement %s',
             $strategy,
-            Strategy::class
+            StrategyInterface::class
         ));
     }
 
@@ -29,7 +29,7 @@ class InvalidStrategyException extends InvalidArgumentException implements Excep
         return new self(sprintf(
             'Invalid strategy of type "%s"; does not implement %s',
             is_object($strategy) ? get_class($strategy) : gettype($strategy),
-            Strategy::class
+            StrategyInterface::class
         ));
     }
 }

--- a/src/LinkGenerator.php
+++ b/src/LinkGenerator.php
@@ -12,11 +12,11 @@ use Psr\Http\Message\ServerRequestInterface;
 class LinkGenerator
 {
     /**
-     * @var LinkGenerator\UrlGenerator
+     * @var LinkGenerator\UrlGeneratorInterface
      */
     private $urlGenerator;
 
-    public function __construct(LinkGenerator\UrlGenerator $urlGenerator)
+    public function __construct(LinkGenerator\UrlGeneratorInterface $urlGenerator)
     {
         $this->urlGenerator = $urlGenerator;
     }

--- a/src/LinkGenerator/ExpressiveUrlGenerator.php
+++ b/src/LinkGenerator/ExpressiveUrlGenerator.php
@@ -11,7 +11,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Zend\Expressive\Helper\ServerUrlHelper;
 use Zend\Expressive\Helper\UrlHelper;
 
-class ExpressiveUrlGenerator implements UrlGenerator
+class ExpressiveUrlGenerator implements UrlGeneratorInterface
 {
     /**
      * @var null|ServerUrlHelper

--- a/src/LinkGenerator/UrlGeneratorInterface.php
+++ b/src/LinkGenerator/UrlGeneratorInterface.php
@@ -12,7 +12,7 @@ use Psr\Http\Message\ServerRequestInterface;
 /**
  * Interface describing a class that can generate a URL for Link HREFs.
  */
-interface UrlGenerator
+interface UrlGeneratorInterface
 {
     /**
      * Generate a URL for use as the HREF of a link.

--- a/src/Renderer/JsonRenderer.php
+++ b/src/Renderer/JsonRenderer.php
@@ -9,7 +9,7 @@ namespace Zend\Expressive\Hal\Renderer;
 
 use Zend\Expressive\Hal\HalResource;
 
-class JsonRenderer implements Renderer
+class JsonRenderer implements RendererInterface
 {
     // @codingStandardsIgnoreStart
     /**

--- a/src/Renderer/RendererInterface.php
+++ b/src/Renderer/RendererInterface.php
@@ -9,7 +9,7 @@ namespace Zend\Expressive\Hal\Renderer;
 
 use Zend\Expressive\Hal\HalResource;
 
-interface Renderer
+interface RendererInterface
 {
     public function render(HalResource $resource) : string;
 }

--- a/src/Renderer/XmlRenderer.php
+++ b/src/Renderer/XmlRenderer.php
@@ -12,7 +12,7 @@ use DOMNode;
 use Zend\Expressive\Hal\HalResource;
 use Zend\Expressive\Hal\Exception;
 
-class XmlRenderer implements Renderer
+class XmlRenderer implements RendererInterface
 {
     public function render(HalResource $resource) : string
     {

--- a/src/ResourceGenerator.php
+++ b/src/ResourceGenerator.php
@@ -29,7 +29,7 @@ class ResourceGenerator
     private $metadataMap;
 
     /**
-     * @var ResourceGenerator\Strategy[]
+     * @var ResourceGenerator\StrategyInterface[]
      */
     private $strategies = [];
 
@@ -79,7 +79,7 @@ class ResourceGenerator
      * Link a metadata type to a strategy that can create a resource for it.
      *
      * @param string $metadataType
-     * @param string|ResourceGenerator\Strategy $strategy
+     * @param string|ResourceGenerator\StrategyInterface $strategy
      */
     public function addStrategy(string $metadataType, $strategy) : void
     {
@@ -92,7 +92,7 @@ class ResourceGenerator
         if (is_string($strategy)
             && (
                 ! class_exists($strategy)
-                || ! in_array(ResourceGenerator\Strategy::class, class_implements($strategy), true)
+                || ! in_array(ResourceGenerator\StrategyInterface::class, class_implements($strategy), true)
             )
         ) {
             throw Exception\InvalidStrategyException::forType($strategy);
@@ -102,7 +102,7 @@ class ResourceGenerator
             $strategy = new $strategy();
         }
 
-        if (! $strategy instanceof ResourceGenerator\Strategy) {
+        if (! $strategy instanceof ResourceGenerator\StrategyInterface) {
             throw Exception\InvalidStrategyException::forInstance($strategy);
         }
 

--- a/src/ResourceGenerator/Exception/OutOfBoundsException.php
+++ b/src/ResourceGenerator/Exception/OutOfBoundsException.php
@@ -9,6 +9,6 @@ namespace Zend\Expressive\Hal\ResourceGenerator\Exception;
 
 use OutOfBoundsException as BaseOutOfBoundsException;
 
-class OutOfBoundsException extends BaseOutOfBoundsException implements Exception
+class OutOfBoundsException extends BaseOutOfBoundsException implements ExceptionInterface
 {
 }

--- a/src/ResourceGenerator/ExtractCollectionTrait.php
+++ b/src/ResourceGenerator/ExtractCollectionTrait.php
@@ -17,7 +17,7 @@ use Zend\Expressive\Hal\ResourceGenerator;
 use Zend\Expressive\Hal\ResourceGenerator\Exception;
 use Zend\Paginator\Paginator;
 
-trait ExtractCollection
+trait ExtractCollectionTrait
 {
     private $paginationTypes = [
         AbstractCollectionMetadata::TYPE_PLACEHOLDER,

--- a/src/ResourceGenerator/ExtractInstanceTrait.php
+++ b/src/ResourceGenerator/ExtractInstanceTrait.php
@@ -14,7 +14,7 @@ use Zend\Expressive\Hal\Metadata\AbstractMetadata;
 use Zend\Expressive\Hal\ResourceGenerator;
 use Zend\Hydrator\ExtractionInterface;
 
-trait ExtractInstance
+trait ExtractInstanceTrait
 {
     /**
      * @param object $instance

--- a/src/ResourceGenerator/RouteBasedCollectionStrategy.php
+++ b/src/ResourceGenerator/RouteBasedCollectionStrategy.php
@@ -16,7 +16,7 @@ use Zend\Expressive\Hal\ResourceGenerator;
 
 class RouteBasedCollectionStrategy implements Strategy
 {
-    use ExtractCollection;
+    use ExtractCollectionTrait;
 
     public function createResource(
         $instance,

--- a/src/ResourceGenerator/RouteBasedCollectionStrategy.php
+++ b/src/ResourceGenerator/RouteBasedCollectionStrategy.php
@@ -14,7 +14,7 @@ use Zend\Expressive\Hal\Link;
 use Zend\Expressive\Hal\Metadata;
 use Zend\Expressive\Hal\ResourceGenerator;
 
-class RouteBasedCollectionStrategy implements Strategy
+class RouteBasedCollectionStrategy implements StrategyInterface
 {
     use ExtractCollectionTrait;
 

--- a/src/ResourceGenerator/RouteBasedResourceStrategy.php
+++ b/src/ResourceGenerator/RouteBasedResourceStrategy.php
@@ -13,7 +13,7 @@ use Zend\Expressive\Hal\Link;
 use Zend\Expressive\Hal\Metadata;
 use Zend\Expressive\Hal\ResourceGenerator;
 
-class RouteBasedResourceStrategy implements Strategy
+class RouteBasedResourceStrategy implements StrategyInterface
 {
     use ExtractInstanceTrait;
 

--- a/src/ResourceGenerator/RouteBasedResourceStrategy.php
+++ b/src/ResourceGenerator/RouteBasedResourceStrategy.php
@@ -15,7 +15,7 @@ use Zend\Expressive\Hal\ResourceGenerator;
 
 class RouteBasedResourceStrategy implements Strategy
 {
-    use ExtractInstance;
+    use ExtractInstanceTrait;
 
     public function createResource(
         $instance,

--- a/src/ResourceGenerator/StrategyInterface.php
+++ b/src/ResourceGenerator/StrategyInterface.php
@@ -12,7 +12,7 @@ use Zend\Expressive\Hal\HalResource;
 use Zend\Expressive\Hal\Metadata;
 use Zend\Expressive\Hal\ResourceGenerator;
 
-interface Strategy
+interface StrategyInterface
 {
     /**
      * @param object $instance Instance from which to create HalResource.

--- a/src/ResourceGenerator/UrlBasedCollectionStrategy.php
+++ b/src/ResourceGenerator/UrlBasedCollectionStrategy.php
@@ -14,7 +14,7 @@ use Zend\Expressive\Hal\Link;
 use Zend\Expressive\Hal\Metadata;
 use Zend\Expressive\Hal\ResourceGenerator;
 
-class UrlBasedCollectionStrategy implements Strategy
+class UrlBasedCollectionStrategy implements StrategyInterface
 {
     use ExtractCollectionTrait;
 

--- a/src/ResourceGenerator/UrlBasedCollectionStrategy.php
+++ b/src/ResourceGenerator/UrlBasedCollectionStrategy.php
@@ -16,7 +16,7 @@ use Zend\Expressive\Hal\ResourceGenerator;
 
 class UrlBasedCollectionStrategy implements Strategy
 {
-    use ExtractCollection;
+    use ExtractCollectionTrait;
 
     public function createResource(
         $instance,

--- a/src/ResourceGenerator/UrlBasedResourceStrategy.php
+++ b/src/ResourceGenerator/UrlBasedResourceStrategy.php
@@ -13,7 +13,7 @@ use Zend\Expressive\Hal\Link;
 use Zend\Expressive\Hal\Metadata;
 use Zend\Expressive\Hal\ResourceGenerator;
 
-class UrlBasedResourceStrategy implements Strategy
+class UrlBasedResourceStrategy implements StrategyInterface
 {
     use ExtractInstanceTrait;
 

--- a/src/ResourceGenerator/UrlBasedResourceStrategy.php
+++ b/src/ResourceGenerator/UrlBasedResourceStrategy.php
@@ -15,7 +15,7 @@ use Zend\Expressive\Hal\ResourceGenerator;
 
 class UrlBasedResourceStrategy implements Strategy
 {
-    use ExtractInstance;
+    use ExtractInstanceTrait;
 
     public function createResource(
         $instance,

--- a/test/LinkGeneratorTest.php
+++ b/test/LinkGeneratorTest.php
@@ -18,7 +18,7 @@ class LinkGeneratorTest extends TestCase
     {
         $request = $this->prophesize(ServerRequestInterface::class)->reveal();
 
-        $urlGenerator = $this->prophesize(LinkGenerator\UrlGenerator::class);
+        $urlGenerator = $this->prophesize(LinkGenerator\UrlGeneratorInterface::class);
         $urlGenerator->generate(
             $request,
             'test',
@@ -48,7 +48,7 @@ class LinkGeneratorTest extends TestCase
     {
         $request = $this->prophesize(ServerRequestInterface::class)->reveal();
 
-        $urlGenerator = $this->prophesize(LinkGenerator\UrlGenerator::class);
+        $urlGenerator = $this->prophesize(LinkGenerator\UrlGeneratorInterface::class);
         $urlGenerator->generate(
             $request,
             'test',

--- a/test/ResourceGeneratorTest.php
+++ b/test/ResourceGeneratorTest.php
@@ -642,7 +642,7 @@ class ResourceGeneratorTest extends TestCase
      * @dataProvider strategyCollection
      * @dataProvider strategyResource
      */
-    public function testUnexpectedMetadataForStrategy(ResourceGenerator\Strategy $strategy)
+    public function testUnexpectedMetadataForStrategy(ResourceGenerator\StrategyInterface $strategy)
     {
         $this->generator->addStrategy(
             TestAsset\TestMetadata::class,
@@ -665,7 +665,7 @@ class ResourceGeneratorTest extends TestCase
      * @dataProvider strategyCollection
      */
     public function testNotTraversableInstanceForCollectionStrategy(
-        ResourceGenerator\Strategy $strategy,
+        ResourceGenerator\StrategyInterface $strategy,
         string $metadata
     ) {
         $collectionMetadata = new $metadata(


### PR DESCRIPTION
In #16, the various `Exception` interfaces were renamed to `ExceptionInterface`, for consistencty with other ZF component packages. This patch takes that a step farther, and applies the same renaming to all interfaces within the package, and does the same for shipped traits.

These include:

- Renaming `ExtractCollection` to `ExtractCollectionTrait`
- Renaming `ExtractInstance` to `ExtractInstanceTrait`
- Renaming `Renderer` to `RendererInterface`
- Renaming `Strategy` to `StrategyInterface`
- Renaming `UrlGenerator` to `UrlGeneratorInterface`

All affected entries within the shipped `ConfigProvider` were updated, as well as all documentation.