### PR TITLE
Fix missing factory for "LinkGenerator\UrlGenerator"

### DIFF
--- a/src/LinkGeneratorFactory.php
+++ b/src/LinkGeneratorFactory.php
@@ -14,7 +14,7 @@ class LinkGeneratorFactory
     public function __invoke(ContainerInterface $container) : LinkGenerator
     {
         return new LinkGenerator(
-            $container->get(LinkGenerator\UrlGenerator::class)
+            $container->get(LinkGenerator\UrlGeneratorInterface::class)
         );
     }
 }


### PR DESCRIPTION
Trying the [introductory documentation](https://docs.zendframework.com/zend-expressive-hal/intro/) leads to this critical exception:

> Zend\ServiceManager\Exception\ServiceNotFoundException: Unable to resolve service "Zend\Expressive\Hal\LinkGenerator\UrlGenerator" to a factory; are you certain you provided it during configuration? in /x/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:681

Seems like this change was forgotten in PR https://github.com/zendframework/zend-expressive-hal/pull/20.


> - Are you fixing a bug?

Yes.

> - Detail how the bug is invoked currently:

Trying to retrieve `Zend\Expressive\Hal\ResourceGenerator` from the Service-Manager (e. g. in a factory for an zend-expressive action).

> - Detail the original, incorrect behavior:

See exception above.

> - Detail the new, expected behavior:

A working instance of `Zend\Expressive\Hal\ResourceGenerator`.

> - Is this related to quality assurance?

Yes, because the library is not working.

> - Is this related to documentation?

 No.
