### PR TITLE
Allow usage with zend-expressive-helpers 5.0 series

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "phpunit/phpunit": "^6.4.3",
         "zendframework/zend-coding-standard": "~1.0.0",
         "zendframework/zend-diactoros": "^1.6",
-        "zendframework/zend-expressive-helpers": "^4.2",
+        "zendframework/zend-expressive-helpers": "^4.2 || ^5.0.0-dev || ^5.0.0",
         "zendframework/zend-hydrator": "^2.3.1",
         "zendframework/zend-paginator": "^2.7"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "863a254455b1cc1476e60cf5194ecf8a",
+    "content-hash": "1ae6038383d96a5ea655303e1f4a509e",
     "packages": [
         {
             "name": "psr/http-message",
@@ -2249,7 +2249,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "zendframework/zend-expressive-helpers": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
Updates the constraint for zend-expressive-helpers to include the 5.0.0-dev and/or 5.0.0 releases, as the API consumed by this package remains compatible.