### PR TITLE
Ensure objects are rendered correctly by the XmlRenderer

### DIFF
--- a/src/Exception/InvalidResourceValueException.php
+++ b/src/Exception/InvalidResourceValueException.php
@@ -20,4 +20,16 @@ class InvalidResourceValueException extends RuntimeException implements Exceptio
             HalResource::class
         ));
     }
+
+    /**
+     * @param object $object
+     */
+    public static function fromObject($object) : self
+    {
+        return new self(sprintf(
+            'Encountered object of type "%s" when serializing %s instance; unable to serialize',
+            get_class($object),
+            HalResource::class
+        ));
+    }
 }

--- a/src/Renderer/XmlRenderer.php
+++ b/src/Renderer/XmlRenderer.php
@@ -112,6 +112,11 @@ class XmlRenderer implements RendererInterface
             return $doc->createElement($name, $data);
         }
 
+        if (is_object($data)) {
+            $data = $this->createDataFromObject($data);
+            return $doc->createElement($name, $data);
+        }
+
         if (! is_array($data)) {
             throw Exception\InvalidResourceValueException::fromValue($data);
         }
@@ -141,5 +146,23 @@ class XmlRenderer implements RendererInterface
         }
 
         return $node;
+    }
+
+    /**
+     * @todo Detect JsonSerializable, and pass to
+     *     json_decode(json_encode($object), true), passing the final value
+     *     back to createResourceElement()?
+     * @todo How should we handle DateTimeInterface implementations?
+     *     $date->format('c')?
+     * @param object $object
+     * @throws Exception\InvalidResourceValueException if unable to serialize
+     *     the data to a string.
+     */
+    private function createDataFromObject($object) : string
+    {
+        if (! method_exists($object, '__toString')) {
+            throw Exception\InvalidResourceValueException::fromObject($object);
+        }
+        return (string) $object;
     }
 }

--- a/src/Renderer/XmlRenderer.php
+++ b/src/Renderer/XmlRenderer.php
@@ -7,6 +7,7 @@
 
 namespace Zend\Expressive\Hal\Renderer;
 
+use DateTimeInterface;
 use DOMDocument;
 use DOMNode;
 use Zend\Expressive\Hal\HalResource;
@@ -152,17 +153,20 @@ class XmlRenderer implements RendererInterface
      * @todo Detect JsonSerializable, and pass to
      *     json_decode(json_encode($object), true), passing the final value
      *     back to createResourceElement()?
-     * @todo How should we handle DateTimeInterface implementations?
-     *     $date->format('c')?
      * @param object $object
      * @throws Exception\InvalidResourceValueException if unable to serialize
      *     the data to a string.
      */
     private function createDataFromObject($object) : string
     {
+        if ($object instanceof DateTimeInterface) {
+            return $object->format('c');
+        }
+
         if (! method_exists($object, '__toString')) {
             throw Exception\InvalidResourceValueException::fromObject($object);
         }
+
         return (string) $object;
     }
 }

--- a/test/Renderer/XmlRendererTest.php
+++ b/test/Renderer/XmlRendererTest.php
@@ -7,7 +7,10 @@
 
 namespace ZendTest\Expressive\Hal\Renderer;
 
+use DateTime;
 use PHPUnit\Framework\TestCase;
+use Zend\Expressive\Hal\HalResource;
+use Zend\Expressive\Hal\Link;
 use Zend\Expressive\Hal\Renderer\XmlRenderer;
 
 class XmlRendererTest extends TestCase
@@ -60,5 +63,18 @@ EOX;
         $renderer = new XmlRenderer();
 
         $this->assertSame($expected, $renderer->render($resource));
+    }
+
+    public function testCanRenderPhpDateTimeInstances()
+    {
+        $dateTime = new DateTime('now');
+        $resource = new HalResource([
+            'date' => $dateTime,
+        ]);
+        $resource = $resource->withLink(new Link('self', '/example'));
+
+        $renderer = new XmlRenderer();
+        $xml = $renderer->render($resource);
+        $this->assertContains((string) $dateTime, $xml);
     }
 }

--- a/test/Renderer/XmlRendererTest.php
+++ b/test/Renderer/XmlRendererTest.php
@@ -9,9 +9,11 @@ namespace ZendTest\Expressive\Hal\Renderer;
 
 use DateTime;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 use Zend\Expressive\Hal\HalResource;
 use Zend\Expressive\Hal\Link;
 use Zend\Expressive\Hal\Renderer\XmlRenderer;
+use ZendTest\Expressive\Hal\TestAsset\StringSerializable;
 
 class XmlRendererTest extends TestCase
 {
@@ -79,5 +81,19 @@ EOX;
         $renderer = new XmlRenderer();
         $xml = $renderer->render($resource);
         $this->assertContains($dateTime->format('c'), $xml);
+    }
+
+    public function testCanRenderObjectsThatImplementToString()
+    {
+        $instance = new StringSerializable();
+
+        $resource = new HalResource([
+            'key' => $instance,
+        ]);
+        $resource = $resource->withLink(new Link('self', '/example'));
+
+        $renderer = new XmlRenderer();
+        $xml = $renderer->render($resource);
+        $this->assertContains((string) $instance, $xml);
     }
 }

--- a/test/Renderer/XmlRendererTest.php
+++ b/test/Renderer/XmlRendererTest.php
@@ -65,6 +65,9 @@ EOX;
         $this->assertSame($expected, $renderer->render($resource));
     }
 
+    /**
+     * @see https://github.com/zendframework/zend-expressive-hal/issues/3
+     */
     public function testCanRenderPhpDateTimeInstances()
     {
         $dateTime = new DateTime('now');
@@ -75,6 +78,6 @@ EOX;
 
         $renderer = new XmlRenderer();
         $xml = $renderer->render($resource);
-        $this->assertContains((string) $dateTime, $xml);
+        $this->assertContains($dateTime->format('c'), $xml);
     }
 }

--- a/test/TestAsset/StringSerializable.php
+++ b/test/TestAsset/StringSerializable.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-hal for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-hal/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Expressive\Hal\TestAsset;
+
+class StringSerializable
+{
+    public function __toString()
+    {
+        return __METHOD__;
+    }
+}


### PR DESCRIPTION
This feature was prompted by #3, which details problems when rendering `DateTime` instances with the `XmlRenderer`. The patch does the following:

- If a `DateTimeInterface` is encountered, it will call its `format()` method using the "c" format (ISO 8601), and use that value in the representation.
- If an object implementing `__toString()` is encountered, it will be cast to a string.
- Otherwise, we raise an exception indicating we cannot serialize it to XML.