### PR TITLE
Include hint regarding optional route parameters into documentation

### DIFF
--- a/docs/book/factories.md
+++ b/docs/book/factories.md
@@ -126,6 +126,11 @@ support them. Create `create<type>(array $metadata)` methods for each
 type you wish to support, where `<type>` is your custom class name, minus
 the namespace.
 
+**Please note**: There is a [known issue](https://github.com/zendframework/zend-expressive-hal/issues/5) for at least Zend Router (probably
+others as well) for using routes with optional parameters. If in doubt, always
+configure your router with separate routing entries for such cases. See the
+issue for a comprehensive example.
+
 ## Zend\Expressive\Hal\ResourceGeneratorFactory
 
 - Registered as service: `Zend\Expressive\Hal\ResourceGenerator`

--- a/docs/book/factories.md
+++ b/docs/book/factories.md
@@ -126,10 +126,12 @@ support them. Create `create<type>(array $metadata)` methods for each
 type you wish to support, where `<type>` is your custom class name, minus
 the namespace.
 
-**Please note**: There is a [known issue](https://github.com/zendframework/zend-expressive-hal/issues/5) for at least Zend Router (probably
-others as well) for using routes with optional parameters. If in doubt, always
-configure your router with separate routing entries for such cases. See the
-issue for a comprehensive example.
+> ### Limitation
+> 
+> There is a [known limitation](https://github.com/zendframework/zend-expressive-hal/issues/5) for at least Zend Router (probably
+> others as well) for using routes with optional parameters. If in doubt, always
+> configure your router with separate routing entries for such cases. See the
+> issue for a comprehensive example.
 
 ## Zend\Expressive\Hal\ResourceGeneratorFactory
 

--- a/docs/book/links-and-resources.md
+++ b/docs/book/links-and-resources.md
@@ -142,10 +142,11 @@ $link = $linkGenerator->templatedFromRoute(
 If you need to generate custom links based on routing, we recommend composing
 the `LinkGenerator` in your own classes to do so.
 
-**Please note**: There is a [known issue](https://github.com/zendframework/zend-expressive-hal/issues/5) for at least Zend Router (probably
-others as well) for using routes with optional parameters. If in doubt, always
-configure your router with separate routing entries for such cases. See the
-issue for a comprehensive example.
+> ### Limitation
+> There is a [known limitation](https://github.com/zendframework/zend-expressive-hal/issues/5) for at least Zend Router (probably
+> others as well) for using routes with optional parameters. If in doubt, always
+> configure your router with separate routing entries for such cases. See the
+> issue for a comprehensive example.
 
 ## Resources
 

--- a/docs/book/links-and-resources.md
+++ b/docs/book/links-and-resources.md
@@ -142,6 +142,11 @@ $link = $linkGenerator->templatedFromRoute(
 If you need to generate custom links based on routing, we recommend composing
 the `LinkGenerator` in your own classes to do so.
 
+**Please note**: There is a [known issue](https://github.com/zendframework/zend-expressive-hal/issues/5) for at least Zend Router (probably
+others as well) for using routes with optional parameters. If in doubt, always
+configure your router with separate routing entries for such cases. See the
+issue for a comprehensive example.
+
 ## Resources
 
 A HAL resource is simply the representation you want to return for your API.


### PR DESCRIPTION
Signed-off-by: Sebastian Leitz <sebastian.leitz@etes.de>

Based on [this comment](https://github.com/zendframework/zend-expressive-hal/issues/5#issuecomment-351408524) by @weierophinney I added a statement about parameterized routes into the documentation. This should prevent some people from scratching their head or trying to suppress Exceptions from deep inside Zend Framework.