### PR TITLE
Allow ResponseInterface service to return a factory

### DIFF
--- a/src/HalResponseFactoryFactory.php
+++ b/src/HalResponseFactoryFactory.php
@@ -62,7 +62,8 @@ class HalResponseFactoryFactory
     private function getResponseInstance(ContainerInterface $container) : ResponseInterface
     {
         if ($container->has(ResponseInterface::class)) {
-            return $container->get(ResponseInterface::class);
+            $response = $container->get(ResponseInterface::class);
+            return is_callable($response) ? $response() : $response;
         }
 
         if (class_exists(Response::class)) {

--- a/test/HalResponseFactoryFactoryTest.php
+++ b/test/HalResponseFactoryFactoryTest.php
@@ -66,4 +66,37 @@ class HalResponseFactoryFactoryTest extends TestCase
         self::assertAttributeInstanceOf(ResponseInterface::class, 'responsePrototype', $instance);
         self::assertAttributeInstanceOf(Closure::class, 'streamFactory', $instance);
     }
+
+    public function testReturnsHalResponseFactoryInstanceWhenResponseInterfaceReturnsFactory()
+    {
+        $jsonRenderer = $this->prophesize(Renderer\JsonRenderer::class)->reveal();
+        $xmlRenderer = $this->prophesize(Renderer\XmlRenderer::class)->reveal();
+        $response = $this->prophesize(ResponseInterface::class)->reveal();
+        $responseFactory = function () use ($response) {
+            return $response;
+        };
+        $stream = new class()
+        {
+            public function __invoke()
+            {
+            }
+        };
+
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->has(Renderer\JsonRenderer::class)->willReturn(true);
+        $container->get(Renderer\JsonRenderer::class)->willReturn($jsonRenderer);
+        $container->has(Renderer\XmlRenderer::class)->willReturn(true);
+        $container->get(Renderer\XmlRenderer::class)->willReturn($xmlRenderer);
+        $container->has(ResponseInterface::class)->willReturn(true);
+        $container->get(ResponseInterface::class)->willReturn($responseFactory);
+        $container->has(StreamInterface::class)->willReturn(true);
+        $container->get(StreamInterface::class)->willReturn($stream);
+
+        $instance = (new HalResponseFactoryFactory())($container->reveal());
+        self::assertInstanceOf(HalResponseFactory::class, $instance);
+        self::assertAttributeSame($jsonRenderer, 'jsonRenderer', $instance);
+        self::assertAttributeSame($xmlRenderer, 'xmlRenderer', $instance);
+        self::assertAttributeSame($response, 'responsePrototype', $instance);
+        self::assertAttributeSame($stream, 'streamFactory', $instance);
+    }
 }


### PR DESCRIPTION
Per Expressive 2.2; allows the instance returned to be a factory, instead of the response itself.