### PR TITLE
Keep original query filters in collection self _links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ Versions prior to 0.4.0 were released as the package "weierophinney/hal".
 
 ### Fixed
 
-- Nothing.
+- [#36](https://github.com/zendframework/zend-expressive-hal/pull/36) 
+    Fixes lost parameter queries in collection output.
 
 ## 1.0.0 - 2018-03-15
 

--- a/src/ResourceGenerator/RouteBasedCollectionStrategy.php
+++ b/src/ResourceGenerator/RouteBasedCollectionStrategy.php
@@ -100,8 +100,18 @@ class RouteBasedCollectionStrategy implements StrategyInterface
         ResourceGenerator $resourceGenerator,
         ServerRequestInterface $request
     ) {
+
+        $routeParams = $metadata->getRouteParams() ?? [];
+        $queryStringArgs = array_merge($request->getQueryParams() ?? [], $metadata->getQueryStringArguments() ?? []);
+
         return $resourceGenerator
             ->getLinkGenerator()
-            ->fromRoute('self', $request, $metadata->getRoute());
+            ->fromRoute(
+                'self',
+                $request,
+                $metadata->getRoute(),
+                $routeParams,
+                $queryStringArgs
+            );
     }
 }

--- a/src/ResourceGenerator/UrlBasedCollectionStrategy.php
+++ b/src/ResourceGenerator/UrlBasedCollectionStrategy.php
@@ -71,7 +71,7 @@ class UrlBasedCollectionStrategy implements StrategyInterface
     ) : Link {
         $paginationParam = $metadata->getPaginationParam();
         $paginationType = $metadata->getPaginationParamType();
-        $url = $metadata->getUrl();
+        $url = $metadata->getUrl() . '?' . http_build_query($request->getQueryParams());;
 
         switch ($paginationType) {
             case Metadata\AbstractCollectionMetadata::TYPE_PLACEHOLDER:
@@ -101,7 +101,14 @@ class UrlBasedCollectionStrategy implements StrategyInterface
         ResourceGenerator $resourceGenerator,
         ServerRequestInterface $request
     ) {
-        return new Link('self', $metadata->getUrl());
+
+        $queryStringArgs = $request->getQueryParams();
+        $url = $metadata->getUrl();
+        if($queryStringArgs !== null) {
+            $url .= '?' . http_build_query($queryStringArgs);
+        }
+
+        return new Link('self', $url);
     }
 
     private function stripUrlFragment(string $url) : string

--- a/src/ResourceGenerator/UrlBasedCollectionStrategy.php
+++ b/src/ResourceGenerator/UrlBasedCollectionStrategy.php
@@ -71,7 +71,7 @@ class UrlBasedCollectionStrategy implements StrategyInterface
     ) : Link {
         $paginationParam = $metadata->getPaginationParam();
         $paginationType = $metadata->getPaginationParamType();
-        $url = $metadata->getUrl() . '?' . http_build_query($request->getQueryParams());;
+        $url = $metadata->getUrl() . '?' . http_build_query($request->getQueryParams());
 
         switch ($paginationType) {
             case Metadata\AbstractCollectionMetadata::TYPE_PLACEHOLDER:
@@ -104,7 +104,7 @@ class UrlBasedCollectionStrategy implements StrategyInterface
 
         $queryStringArgs = $request->getQueryParams();
         $url = $metadata->getUrl();
-        if($queryStringArgs !== null) {
+        if ($queryStringArgs !== null) {
             $url .= '?' . http_build_query($queryStringArgs);
         }
 

--- a/test/ResourceGenerator/NestedCollectionResourceGenerationTest.php
+++ b/test/ResourceGenerator/NestedCollectionResourceGenerationTest.php
@@ -153,7 +153,9 @@ class NestedCollectionResourceGenerationTest extends TestCase
             ->fromRoute(
                 'self',
                 $request->reveal(),
-                'collection'
+                'collection',
+                [],
+                []
             )
             ->willReturn(new Link('self', '/api/collection'));
 


### PR DESCRIPTION
Provide a narrative description of what you are trying to accomplish:

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
Request collection with `localhost:8080/clients/?radius=5`
  - [x] Detail the original, incorrect behavior.
Filter parameters specified were lost on HAL generation. Output had no way to tell what filters produced the resultant collection
  - [x] Detail the new, expected behavior.
Output should keep filter parameters to be clear how the results were achieved.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
  - [x] Add a `CHANGELOG.md` entry for the fix.