### PR TITLE
Allow empty array in data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,9 @@ Versions prior to 0.4.0 were released as the package "weierophinney/hal".
 
 ### Fixed
 
-- Nothing.
+- [#34](https://github.com/zendframework/zend-expressive-hal/pull/37) adds ability
+  to provide _empty_ values eg. empty array as element data and avoids addition of
+  of empty data as **embedded** element.
 
 ## 1.0.0 - 2018-03-15
 

--- a/src/HalResource.php
+++ b/src/HalResource.php
@@ -61,7 +61,7 @@ class HalResource implements EvolvableLinkProviderInterface, JsonSerializable
         $context = __CLASS__;
         array_walk($data, function ($value, $name) use ($context) {
             $this->validateElementName($name, $context);
-            if (!empty($value) && ($value instanceof self || $this->isResourceCollection($value, $name, $context))) {
+            if (! empty($value) && ($value instanceof self || $this->isResourceCollection($value, $name, $context))) {
                 $this->embedded[$name] = $value;
                 return;
             }
@@ -148,7 +148,7 @@ class HalResource implements EvolvableLinkProviderInterface, JsonSerializable
     {
         $this->validateElementName($name, __METHOD__);
 
-        if (!empty($value) && ($value instanceof self || $this->isResourceCollection($value, $name, __METHOD__))) {
+        if (! empty($value) && ($value instanceof self || $this->isResourceCollection($value, $name, __METHOD__))) {
             return $this->embed($name, $value);
         }
 

--- a/src/HalResource.php
+++ b/src/HalResource.php
@@ -61,7 +61,7 @@ class HalResource implements EvolvableLinkProviderInterface, JsonSerializable
         $context = __CLASS__;
         array_walk($data, function ($value, $name) use ($context) {
             $this->validateElementName($name, $context);
-            if ($value instanceof self || $this->isResourceCollection($value, $name, $context)) {
+            if (!empty($value) && ($value instanceof self || $this->isResourceCollection($value, $name, $context))) {
                 $this->embedded[$name] = $value;
                 return;
             }
@@ -148,7 +148,7 @@ class HalResource implements EvolvableLinkProviderInterface, JsonSerializable
     {
         $this->validateElementName($name, __METHOD__);
 
-        if ($value instanceof self || $this->isResourceCollection($value, $name, __METHOD__)) {
+        if (!empty($value) && ($value instanceof self || $this->isResourceCollection($value, $name, __METHOD__))) {
             return $this->embed($name, $value);
         }
 

--- a/test/HalResourceTest.php
+++ b/test/HalResourceTest.php
@@ -92,6 +92,14 @@ class HalResourceTest extends TestCase
         $resource = new HalResource([], [], ['foo' => 'bar']);
     }
 
+    public function testEmptyArrayAsDataWillNotBeEmbeddedDuringConstruction()
+    {
+        $resource = new HalResource(['bar' => []]);
+        $this->assertEquals(['bar' => []], $resource->getElements());
+        $representation = $resource->toArray();
+        $this->assertArrayNotHasKey('_embeded', $representation);
+    }
+
     /**
      * @dataProvider invalidElementNames
      */
@@ -220,6 +228,15 @@ class HalResourceTest extends TestCase
         $this->assertNotSame($resource, $new);
         $this->assertEquals([], $resource->getElements());
         $this->assertEquals(['foo' => $collection], $new->getElements());
+    }
+
+    public function testWithElementNotProxiesToEmbededIfEmptyArrayValueProvided()
+    {
+        $resource = new HalResource(['foo' => 'bar']);
+        $new = $resource->withElement('bar', []);
+
+        $representation = $new->toArray();
+        $this->assertEquals(['foo' => 'bar', 'bar' => []], $representation);
     }
 
     /**


### PR DESCRIPTION
Provide a narrative description of what you are trying to accomplish:

## Checklist
- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior.
  - [x] Detail the new, expected behavior.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
  - [x] Add a `CHANGELOG.md` entry for the fix.

## Detail how the bug is invoked currently
<details>
<summary>The bug could currently invoked as follows:</summary>

```php
$resource = new HalResource(
    [
        'empty_list' => [],
    ]
);
```
</details>

## Detail the original, incorrect behavior
<details>
<summary>The original, incorrect behavior is as follows:</summary>

```php
$data = [
    'integer_value' => 1,
    'boolean_value' => true,
    'string_value' => 'string',
    'null_value' => null,
    'associative_array' => [
        'key' => 'value',
        'empty_array' => [],
    ],
    'empty_array' => [],
];
$links = [];
$embedded = [];

$resource = new \Zend\Expressive\Hal\HalResource($data, $links, $embedded);

var_export($resource->toArray()); // -> will produce the following output:

/*
[
    'integer_value' => 1,
    'boolean_value' => true,
    'string_value' => 'string',
    'null_value' => null,
    'appositive_array' => [
        'key' => 'value',
        'empty_array' => [
        ],
    ],
    '_embedded' => [
        'empty_array' => [
        ],
    ],
];
*/
```
</details>

The **empty_array** within data **$data** array is inserted into the **_embedded** key instead of remaining with the other values.

## Detail the new, expected behavior
<details>
<summary>The new, expected behavior should be as follows:</summary>

```php
$data = [
    'integer_value' => 1,
    'boolean_value' => true,
    'string_value' => 'string',
    'null_value' => null,
    'associative_array' => [
        'key' => 'value',
        'empty_array' => [],
    ],
    'empty_array' => [],
];
$links = [];
$embedded = [];

$resource = new \Zend\Expressive\Hal\HalResource($data, $links, $embedded);

var_export($resource->toArray()); // -> will produce the following output:

/*
[
    'integer_value' => 1,
    'boolean_value' => true,
    'string_value' => 'string',
    'null_value' => null,
    'associative_array' => [
        'key' => 'value',
        'empty_list' => [],
    ],
    'empty_list' => [],
];
*/
```
</details>

The **empty_array** within data **$data** array remains with the other values.

## Examples how to create an item and an collection resource
<details>
<summary>Example how an item resource will be created</summary>

```php
$data = [
    'identifier' => 432143,
    'first_name' => 'John',
    'last_name' => 'Doe',
    'roles' => [],
];
$links = [
    new \Zend\Expressive\Hal\Link(
        'self',
        '/users/432143'
    ),
];
$embedded = [];

$resource = new \Zend\Expressive\Hal\HalResource($data, $links, $embedded);

var_export($resource->toArray()); // -> will produce the following output:

/* 
[
    'identifier' => 432143,
    'first_name' => 'John',
    'last_name' => 'Doe',
    'roles' => [],
    '_links' => [
        '_self' => [
            'href' => '/users/432143',
        ],
    ],
]
/*
```
</details>

<details>
<summary>Example how an collection resource will be created, for example as an result of an search. This is also the current behavior when using the `ResourceGenerator`.</summary>

```php
$data = [
    '_total_items' => 0,
    '_page' => 1,
    '_page_count' => 0,
];
$links = [
    new \Zend\Expressive\Hal\Link(
        'self',
        '/users?page=1&limit=10&search=Jane'
    ),
];
$embedded = [
    'users' => [],
];

$resource = new \Zend\Expressive\Hal\HalResource($data, $links, $embedded);

var_export($resource->toArray()); // -> will produce the following output:

/*    
[
    '_total_items' => 0,
    '_page' => 1,
    '_page_count' => 0,
    '_links' => [
        'self' => [
            'href' => '/users?page=1&limit=10&search=Jane',
        ],
    ],
    '_embedded' => [
        'users' => [],
    ],
]
*/
```
</details>

## Example how to explicit embed an empty list
<details>
<summary>Describing how to embed an empty array inside of an created **resource**:</summary>

```php
$resource = new \Zend\Expressive\Hal\HalResource();

$withEmbedded = $resource->embed('users', []);

var_export($withEmbedded->toArray()); // -> will produce the following output:

/*
[
    '_embedded' => [
        'users' => [],
    ],
]
*/
```
</details>
This PR should solve issue: [#34](https://github.com/zendframework/zend-expressive-hal/issues/34)