### PR TITLE
Fixed links to PRs in the CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -448,7 +448,7 @@ Versions prior to 0.4.0 were released as the package "weierophinney/hal".
 
 ### Added
 
-- [#1](https://github.com/weierophinney/pull/1) adds a `Hal\Renderer`
+- [#1](https://github.com/weierophinney/hal/pull/1) adds a `Hal\Renderer`
   subcomponent with the following:
   - `Renderer` interface
   - `JsonRenderer`, for creating JSON representations of `HalResource` instances.
@@ -456,7 +456,7 @@ Versions prior to 0.4.0 were released as the package "weierophinney/hal".
 
 ### Changed
 
-- [#1](https://github.com/weierophinney/pull/1) changes `Hal\HalResponseFactory`
+- [#1](https://github.com/weierophinney/hal/pull/1) changes `Hal\HalResponseFactory`
   to compose a `JsonRenderer` and `XmlRenderer`, instead of composing
   `$jsonFlags` and creating representations itself. 
 
@@ -475,7 +475,7 @@ Versions prior to 0.4.0 were released as the package "weierophinney/hal".
   ) {
   ```
 
-- [#1](https://github.com/weierophinney/pull/1) changes `Hal\HalResponseFactoryFactory`
+- [#1](https://github.com/weierophinney/hal/pull/1) changes `Hal\HalResponseFactoryFactory`
   to comply with the new constructor signature of `Hal\HalResponseFactory`. It
   also updates to check for `Psr\Http\Message\ResponseInterface` and
   `Psr\Http\Message\StreamInterface` services before attempting to use


### PR DESCRIPTION
- [x] Is this related to documentation?
  <!-- Is it a typographical and/or grammatical fix? -->
  <!-- Is it new documentation? -->

These are also wrong here:
https://github.com/weierophinney/hal/releases/tag/0.2.0
