### PR TITLE
Update path-segregated-uri-generation.md

### DIFF
--- a/docs/book/cookbook/path-segregated-uri-generation.md
+++ b/docs/book/cookbook/path-segregated-uri-generation.md
@@ -5,7 +5,7 @@
 You may want to develop your API as a separate module that you can then drop in
 to an existing application; you may even want to [path-segregate](https://docs.zendframework.com/zend-expressive/v3/features/router/piping/#path-segregation) it.
 
-In such cases, you will want to use a different router instance, which has a
+In such cases, you will want to use a different router instance to isolate your routes, which has a
 huge number of ramifications:
 
 - You'll need separate routing middleware.
@@ -49,6 +49,7 @@ use Zend\Expressive\Helper\UrlHelperFactory;
 use Zend\Expressive\Helper\UrlHelperMiddlewareFactory;
 use Zend\Expressive\Router\FastRouteRouter;
 use Zend\Expressive\Router\Middleware\RouteMiddlewareFactory;
+use Zend\Expressive\Router\FastRouteRouterFactory;
 
 class ConfigProvider
 {
@@ -213,6 +214,7 @@ namespace Api;
 use Psr\Container\ContainerInterface;
 use Zend\Expressive\MiddlewareFactory;
 use Zend\Expressive\Router\Middleware as RouterMiddleware;
+use Zend\Expressive\Router\RouteCollector;
 use Zend\ProblemDetails\ProblemDetailsMiddleware;
 use Zend\ProblemDetails\ProblemDetailsNotFoundHandler;
 use Zend\Stratigility\MiddlewarePipe;


### PR DESCRIPTION
Added a couple of necessary `use` statements. See here for a proof-of-concept including an example of the use of `host()`  middleware that adds a base path before segregating by that path:

https://github.com/marcguyer/zend-expressive-path-segregation

I didn't modify the docs accordingly but in my opinion, the concept of using `::class` with class names that don't exist in order to create _virtual_ service names in the current namespace is too magical. It's neato, but confusing. I'd rather see any service key that isn't really a class on its own to be a simple string for clarity. I've done that in my example implementation linked above. Another argument for this is the fact that any IDE, linter, or CS fixer is going to complain about an instance of the use of `::class` for a class that doesn't exist.

Provide a narrative description of what you are trying to accomplish:

- [x] Is this related to documentation?
  <!-- Is it a typographical and/or grammatical fix? -->
  <!-- Is it new documentation? -->
