### PR TITLE
Fix HalResource constructor phpdoc

### DIFF
--- a/src/HalResource.php
+++ b/src/HalResource.php
@@ -54,7 +54,7 @@ class HalResource implements EvolvableLinkProviderInterface, JsonSerializable
     /**
      * @param array $data
      * @param LinkInterface[] $links
-     * @param HalResource[] $embedded
+     * @param HalResource[][] $embedded
      */
     public function __construct(array $data = [], array $links = [], array $embedded = [])
     {


### PR DESCRIPTION
This fixes HalResource constructor phpdoc, which in fact is an array of HalResource arrays 

- [ ] Are you fixing a bug?
  - [ ] Detail how the bug is invoked currently.
  - [ ] Detail the original, incorrect behavior.
  - [ ] Detail the new, expected behavior.
  - [ ] Base your feature on the `master` branch, and submit against that branch.
  - [ ] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.

- [ ] Are you creating a new feature?
  - [ ] Why is the new feature needed? What purpose does it serve?
  - [ ] How will users use the new feature?
  - [ ] Base your feature on the `develop` branch, and submit against that branch.
  - [ ] Add only one feature per pull request; split multiple features over multiple pull requests
  - [ ] Add tests for the new feature.
  - [ ] Add documentation for the new feature.
  - [ ] Add a `CHANGELOG.md` entry for the new feature.

- [x] Is this related to quality assurance?

This is a small annoyance, because every time I manually create a HalResource in my app with embeds, `phpstan` throws an error.

`Parameter #3 $embedded of class Zend\Expressive\Hal\HalResource constructor expects array<Zend\Expressive\Hal\HalResource>, array<string, array<int, Zend\Expressive\Hal\HalResource>> given.`

- [ ] Is this related to documentation?
  <!-- Is it a typographical and/or grammatical fix? -->
  <!-- Is it new documentation? -->
