### PR TITLE
Generate paginated collections for Doctrine paginators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ Versions prior to 0.4.0 were released as the package "weierophinney/hal".
 
 ### Added
 
-- Nothing.
+- [#55](https://github.com/zendframework/zend-expressive-hal/pull/55) adds the ability to generate paginated HAL collections from
+  `Doctrine\ORM\Tools\Pagination\Paginator` instances.
 
 ### Changed
 

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "willdurand/negotiation": "^2.3.1"
     },
     "require-dev": {
+        "doctrine/orm": "^2.6",
         "phpunit/phpunit": "^7.0.1",
         "zendframework/zend-coding-standard": "~1.0.0",
         "zendframework/zend-expressive-helpers": "^5.0.0alpha3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eb9959ea3eea92401b8db98effc3683c",
+    "content-hash": "5dda7e8b0aba3488d4d0c22f78073f48",
     "packages": [
         {
             "name": "psr/http-message",
@@ -160,6 +160,520 @@
     ],
     "packages-dev": [
         {
+            "name": "doctrine/annotations",
+            "version": "v1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/annotations.git",
+                "reference": "c7f2050c68a9ab0bdb0f98567ec08d80ea7d24d5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/c7f2050c68a9ab0bdb0f98567ec08d80ea7d24d5",
+                "reference": "c7f2050c68a9ab0bdb0f98567ec08d80ea7d24d5",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "1.*",
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "doctrine/cache": "1.*",
+                "phpunit/phpunit": "^6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Docblock Annotations Parser",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "parser"
+            ],
+            "time": "2017-12-06T07:11:42+00:00"
+        },
+        {
+            "name": "doctrine/cache",
+            "version": "v1.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/cache.git",
+                "reference": "d768d58baee9a4862ca783840eca1b9add7a7f57"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/d768d58baee9a4862ca783840eca1b9add7a7f57",
+                "reference": "d768d58baee9a4862ca783840eca1b9add7a7f57",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~7.1"
+            },
+            "conflict": {
+                "doctrine/common": ">2.2,<2.4"
+            },
+            "require-dev": {
+                "alcaeus/mongo-php-adapter": "^1.1",
+                "doctrine/coding-standard": "^4.0",
+                "mongodb/mongodb": "^1.1",
+                "phpunit/phpunit": "^7.0",
+                "predis/predis": "~1.0"
+            },
+            "suggest": {
+                "alcaeus/mongo-php-adapter": "Required to use legacy MongoDB driver"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Cache\\": "lib/Doctrine/Common/Cache"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Caching library offering an object-oriented API for many cache backends",
+            "homepage": "https://www.doctrine-project.org",
+            "keywords": [
+                "cache",
+                "caching"
+            ],
+            "time": "2018-08-21T18:01:43+00:00"
+        },
+        {
+            "name": "doctrine/collections",
+            "version": "v1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/collections.git",
+                "reference": "a01ee38fcd999f34d9bfbcee59dbda5105449cbf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/collections/zipball/a01ee38fcd999f34d9bfbcee59dbda5105449cbf",
+                "reference": "a01ee38fcd999f34d9bfbcee59dbda5105449cbf",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "~0.1@dev",
+                "phpunit/phpunit": "^5.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\Collections\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Collections Abstraction library",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "array",
+                "collections",
+                "iterator"
+            ],
+            "time": "2017-07-22T10:37:32+00:00"
+        },
+        {
+            "name": "doctrine/common",
+            "version": "v2.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/common.git",
+                "reference": "30e33f60f64deec87df728c02b107f82cdafad9d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/common/zipball/30e33f60f64deec87df728c02b107f82cdafad9d",
+                "reference": "30e33f60f64deec87df728c02b107f82cdafad9d",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/annotations": "^1.0",
+                "doctrine/cache": "^1.0",
+                "doctrine/collections": "^1.0",
+                "doctrine/event-manager": "^1.0",
+                "doctrine/inflector": "^1.0",
+                "doctrine/lexer": "^1.0",
+                "doctrine/persistence": "^1.1",
+                "doctrine/reflection": "^1.0",
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^1.0",
+                "phpunit/phpunit": "^6.3",
+                "squizlabs/php_codesniffer": "^3.0",
+                "symfony/phpunit-bridge": "^4.0.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.10.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\": "lib/Doctrine/Common"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                },
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "PHP Doctrine Common project is a library that provides additional functionality that other Doctrine projects depend on such as better reflection support, persistence interfaces, proxies, event system and much more.",
+            "homepage": "https://www.doctrine-project.org/projects/common.html",
+            "keywords": [
+                "common",
+                "doctrine",
+                "php"
+            ],
+            "time": "2018-11-21T01:24:55+00:00"
+        },
+        {
+            "name": "doctrine/dbal",
+            "version": "v2.9.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/dbal.git",
+                "reference": "22800bd651c1d8d2a9719e2a3dc46d5108ebfcc9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/22800bd651c1d8d2a9719e2a3dc46d5108ebfcc9",
+                "reference": "22800bd651c1d8d2a9719e2a3dc46d5108ebfcc9",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/cache": "^1.0",
+                "doctrine/event-manager": "^1.0",
+                "ext-pdo": "*",
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^5.0",
+                "jetbrains/phpstorm-stubs": "^2018.1.2",
+                "phpstan/phpstan": "^0.10.1",
+                "phpunit/phpunit": "^7.4",
+                "symfony/console": "^2.0.5|^3.0|^4.0",
+                "symfony/phpunit-bridge": "^3.4.5|^4.0.5"
+            },
+            "suggest": {
+                "symfony/console": "For helpful console commands such as SQL execution and import of files."
+            },
+            "bin": [
+                "bin/doctrine-dbal"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.9.x-dev",
+                    "dev-develop": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\DBAL\\": "lib/Doctrine/DBAL"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                }
+            ],
+            "description": "Powerful PHP database abstraction layer (DBAL) with many features for database schema introspection and management.",
+            "homepage": "https://www.doctrine-project.org/projects/dbal.html",
+            "keywords": [
+                "abstraction",
+                "database",
+                "dbal",
+                "mysql",
+                "persistence",
+                "pgsql",
+                "php",
+                "queryobject"
+            ],
+            "time": "2018-12-31T03:27:51+00:00"
+        },
+        {
+            "name": "doctrine/event-manager",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/event-manager.git",
+                "reference": "a520bc093a0170feeb6b14e9d83f3a14452e64b3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/event-manager/zipball/a520bc093a0170feeb6b14e9d83f3a14452e64b3",
+                "reference": "a520bc093a0170feeb6b14e9d83f3a14452e64b3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "conflict": {
+                "doctrine/common": "<2.9@dev"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^4.0",
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\": "lib/Doctrine/Common"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                },
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "Doctrine Event Manager component",
+            "homepage": "https://www.doctrine-project.org/projects/event-manager.html",
+            "keywords": [
+                "event",
+                "eventdispatcher",
+                "eventmanager"
+            ],
+            "time": "2018-06-11T11:59:03+00:00"
+        },
+        {
+            "name": "doctrine/inflector",
+            "version": "v1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/inflector.git",
+                "reference": "5527a48b7313d15261292c149e55e26eae771b0a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/5527a48b7313d15261292c149e55e26eae771b0a",
+                "reference": "5527a48b7313d15261292c149e55e26eae771b0a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Inflector\\": "lib/Doctrine/Common/Inflector"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Common String Manipulations with regard to casing and singular/plural rules.",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "inflection",
+                "pluralize",
+                "singularize",
+                "string"
+            ],
+            "time": "2018-01-09T20:05:19+00:00"
+        },
+        {
             "name": "doctrine/instantiator",
             "version": "1.1.0",
             "source": {
@@ -212,6 +726,299 @@
                 "instantiate"
             ],
             "time": "2017-07-22T11:58:36+00:00"
+        },
+        {
+            "name": "doctrine/lexer",
+            "version": "v1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/lexer.git",
+                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/83893c552fd2045dd78aef794c31e694c37c0b8c",
+                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\Lexer\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Base library for a lexer that can be used in Top-Down, Recursive Descent Parsers.",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "lexer",
+                "parser"
+            ],
+            "time": "2014-09-09T13:34:57+00:00"
+        },
+        {
+            "name": "doctrine/orm",
+            "version": "v2.6.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/orm.git",
+                "reference": "434820973cadf2da2d66e7184be370084cc32ca8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/orm/zipball/434820973cadf2da2d66e7184be370084cc32ca8",
+                "reference": "434820973cadf2da2d66e7184be370084cc32ca8",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/annotations": "~1.5",
+                "doctrine/cache": "~1.6",
+                "doctrine/collections": "^1.4",
+                "doctrine/common": "^2.7.1",
+                "doctrine/dbal": "^2.6",
+                "doctrine/instantiator": "~1.1",
+                "ext-pdo": "*",
+                "php": "^7.1",
+                "symfony/console": "~3.0|~4.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^1.0",
+                "phpunit/phpunit": "^6.5",
+                "squizlabs/php_codesniffer": "^3.2",
+                "symfony/yaml": "~3.4|~4.0"
+            },
+            "suggest": {
+                "symfony/yaml": "If you want to use YAML Metadata Mapping Driver"
+            },
+            "bin": [
+                "bin/doctrine"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\ORM\\": "lib/Doctrine/ORM"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "Object-Relational-Mapper for PHP",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "database",
+                "orm"
+            ],
+            "time": "2018-11-20T23:46:46+00:00"
+        },
+        {
+            "name": "doctrine/persistence",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/persistence.git",
+                "reference": "c0f1c17602afc18b4cbd8e1c8125f264c9cf7d38"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/persistence/zipball/c0f1c17602afc18b4cbd8e1c8125f264c9cf7d38",
+                "reference": "c0f1c17602afc18b4cbd8e1c8125f264c9cf7d38",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/annotations": "^1.0",
+                "doctrine/cache": "^1.0",
+                "doctrine/collections": "^1.0",
+                "doctrine/event-manager": "^1.0",
+                "doctrine/reflection": "^1.0",
+                "php": "^7.1"
+            },
+            "conflict": {
+                "doctrine/common": "<2.10@dev"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^5.0",
+                "phpstan/phpstan": "^0.8",
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\": "lib/Doctrine/Common"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                },
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "The Doctrine Persistence project is a set of shared interfaces and functionality that the different Doctrine object mappers share.",
+            "homepage": "https://doctrine-project.org/projects/persistence.html",
+            "keywords": [
+                "mapper",
+                "object",
+                "odm",
+                "orm",
+                "persistence"
+            ],
+            "time": "2018-11-21T00:33:13+00:00"
+        },
+        {
+            "name": "doctrine/reflection",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/reflection.git",
+                "reference": "02538d3f95e88eb397a5f86274deb2c6175c2ab6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/reflection/zipball/02538d3f95e88eb397a5f86274deb2c6175c2ab6",
+                "reference": "02538d3f95e88eb397a5f86274deb2c6175c2ab6",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/annotations": "^1.0",
+                "ext-tokenizer": "*",
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^4.0",
+                "doctrine/common": "^2.8",
+                "phpstan/phpstan": "^0.9.2",
+                "phpstan/phpstan-phpunit": "^0.9.4",
+                "phpunit/phpunit": "^7.0",
+                "squizlabs/php_codesniffer": "^3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\": "lib/Doctrine/Common"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                },
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "Doctrine Reflection component",
+            "homepage": "https://www.doctrine-project.org/projects/reflection.html",
+            "keywords": [
+                "reflection"
+            ],
+            "time": "2018-06-14T14:45:07+00:00"
         },
         {
             "name": "fig/http-message-util",
@@ -1759,6 +2566,205 @@
                 "standards"
             ],
             "time": "2018-11-07T22:31:41+00:00"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v4.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "1f0ad51dfde4da8a6070f06adc58b4e37cbb37a4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/1f0ad51dfde4da8a6070f06adc58b4e37cbb37a4",
+                "reference": "1f0ad51dfde4da8a6070f06adc58b4e37cbb37a4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/contracts": "^1.0",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<3.4",
+                "symfony/process": "<3.3"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "~3.4|~4.0",
+                "symfony/dependency-injection": "~3.4|~4.0",
+                "symfony/event-dispatcher": "~3.4|~4.0",
+                "symfony/lock": "~3.4|~4.0",
+                "symfony/process": "~3.4|~4.0"
+            },
+            "suggest": {
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/lock": "",
+                "symfony/process": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Console Component",
+            "homepage": "https://symfony.com",
+            "time": "2019-01-25T14:35:16+00:00"
+        },
+        {
+            "name": "symfony/contracts",
+            "version": "v1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/contracts.git",
+                "reference": "1aa7ab2429c3d594dd70689604b5cf7421254cdf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/contracts/zipball/1aa7ab2429c3d594dd70689604b5cf7421254cdf",
+                "reference": "1aa7ab2429c3d594dd70689604b5cf7421254cdf",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "require-dev": {
+                "psr/cache": "^1.0",
+                "psr/container": "^1.0"
+            },
+            "suggest": {
+                "psr/cache": "When using the Cache contracts",
+                "psr/container": "When using the Service contracts",
+                "symfony/cache-contracts-implementation": "",
+                "symfony/service-contracts-implementation": "",
+                "symfony/translation-contracts-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\": ""
+                },
+                "exclude-from-classmap": [
+                    "**/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A set of abstractions extracted out of the Symfony components",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2018-12-05T08:06:11+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "c79c051f5b3a46be09205c73b80b346e4153e494"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/c79c051f5b3a46be09205c73b80b346e4153e494",
+                "reference": "c79c051f5b3a46be09205c73b80b346e4153e494",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2018-09-21T13:07:52+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/docs/book/doctrine.md
+++ b/docs/book/doctrine.md
@@ -1,0 +1,421 @@
+# Generating HAL from Doctrine
+
+> - Since 1.3.0
+
+[Doctrine](https://www.doctrine-project.org/) is a well-known and popular Object
+Relational Mapper; you will find it in use across pretty much every PHP
+framework. Expressive is no different.
+
+How do you generate HAL for Doctrine resources? As it turns out, the same way
+you would for any other objects you might have: create metadata mapping the
+objects you want to represent to the routes and the hydrators/collections to use
+when extracting them.
+
+## Example: Paginated Albums
+
+In this example, we have an entity named `Album` that we want to expose via a
+paginated HAL representation. Over the course of the example, we will create a
+custom collection class based off of the Doctrine `Paginator` class, and map it
+as a HAL collection.
+
+Our first step is defining an entity:
+
+```php
+declare(strict_types=1);
+
+namespace Album\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Ramsey\Uuid\Uuid;
+
+/**
+ * https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/basic-mapping.html
+ *
+ * @ORM\Entity
+ * @ORM\Table(name="albums")
+ **/
+class Album
+{
+    /**
+     * @var Uuid
+     *
+     * @ORM\Id
+     * @ORM\Column(type="uuid", unique=true)
+     * @ORM\GeneratedValue(strategy="CUSTOM")
+     * @ORM\CustomIdGenerator(class="Ramsey\Uuid\Doctrine\UuidGenerator")
+     */
+    protected $id;
+
+    /**
+     * @ORM\Column(type="string", nullable=false)
+     */
+    protected $title;
+
+    /**
+     * @ORM\Column(type="datetime", nullable=false)
+     */
+    protected $created;
+
+    /**
+     * @ORM\Column(type="datetime")
+     */
+    protected $modified;
+
+    /**
+     * @return Uuid
+     */
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    /**
+     * @param string $title
+     */
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getCreated(): \DateTime
+    {
+        return $this->created;
+    }
+
+    /**
+     * @param \DateTime $created
+     * @throws \Exception
+     */
+    public function setCreated(\DateTime $created = null): void
+    {
+        if (!$created && empty($this->getId())) {
+            $this->created = new \DateTime("now");
+        } else {
+            $this->created = $created;
+        }
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getModified(): \DateTime
+    {
+        return $this->modified;
+    }
+
+    /**
+     * @param \DateTime $modified
+     * @throws \Exception
+     */
+    public function setModified(\DateTime $modified = null): void
+    {
+        if (!$modified) {
+            $this->modified = new \DateTime("now");
+        } else {
+            $this->modified = $modified;
+        }
+    }
+}
+```
+
+In order to work with this, we need to provide Doctrine persistence mapping
+configuration. We will do this in the `ConfigProvider` for this module:
+
+```php
+declare(strict_types=1);
+
+namespace Album;
+
+use Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain;
+use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
+
+class ConfigProvider
+{
+    public function __invoke() : array
+    {
+        return [
+            'dependencies' => $this->getDependencies(),
+            'doctrine'     => $this->getDoctrineEntities(),
+        ];
+    }
+
+    public function getDependencies() : array
+    {
+        return [
+        ];
+    }
+
+    public function getDoctrineEntities() : array
+    {
+        return [
+            'driver' => [
+                'orm_default' => [
+                    'class' => MappingDriverChain::class,
+                    'drivers' => [
+                        'Album\Entity' => 'album_entity',
+                    ],
+                ],
+                'album_entity' => [
+                    'class' => AnnotationDriver::class,
+                    'cache' => 'array',
+                    'paths' => [__DIR__ . '/Entity'],
+                ],
+            ],
+        ];
+    }
+}
+```
+
+Next, in order to provide a HAL _collection_ representation, we will create a
+custom `Doctrine\ORM\Tools\Pagination\Paginator` extension:
+
+```php
+declare(strict_types=1);
+
+namespace Album\Entity;
+
+use Doctrine\ORM\Tools\Pagination\Paginator;
+
+class AlbumCollection extends Paginator
+{
+}
+```
+
+From here, we will add configuration of our HAL metadata map to the
+`ConfigProvider`. First, we will add the following method to configure both our
+entity and our collection:
+
+```php
+// Add these imports to the top of the class file
+use Zend\Expressive\Hal\Metadata\RouteBasedCollectionMetadata;
+use Zend\Expressive\Hal\Metadata\RouteBasedResourceMetadata;
+use Zend\Hydrator\ReflectionHydrator;
+
+
+    // Add this method inside the ConfigProvider class:
+    public function getHalMetadataMap()
+    {
+        return [
+            [
+                '__class__'      => RouteBasedResourceMetadata::class,
+                'resource_class' => Entity\Album::class,
+                'route'          => 'albums.show', // assumes a route named 'albums.show' has been created
+                'extractor'      => ReflectionHydrator::class,
+            ],
+            [
+                '__class__'           => RouteBasedCollectionMetadata::class,
+                'collection_class'    => Entity\AlbumCollection::class,
+                'collection_relation' => 'album',
+                'route'               => 'albums.list', // assumes a route named 'albums.list' has been created
+            ],
+        ];
+    }
+```
+
+Then, within the `__invoke()` method, we will assign the return value of that
+method to the key `MetadataMap::class`:
+
+```php
+// Add this import to the top of the class file:
+use Zend\Expressive\Hal\Metadata\MetadataMap;
+
+    // Modify this ConfigProvider method to read:
+    public function __invoke() : array
+    {
+        return [
+            'dependencies' => $this->getDependencies(),
+            'templates'    => $this->getTemplates(),
+            'doctrine'     => $this->getDoctrineEntities(),
+            MetadataMap::class => $this->getHalMetadataMap(),
+        ];
+    }
+```
+
+With these in place, we can write a handler that will display a collection as
+follows:
+
+```php
+declare(strict_types=1);
+
+namespace Album\Handler;
+
+use Album\Entity\Album;
+use Album\Entity\AlbumCollection;
+use Doctrine\ORM\EntityManager;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Zend\Expressive\Hal\HalResponseFactory;
+use Zend\Expressive\Hal\ResourceGenerator;
+
+class ListAlbumsHandler implements RequestHandlerInterface
+{
+    protected $entityManager;
+    protected $pageCount;
+    protected $responseFactory;
+    protected $resourceGenerator;
+
+    public function __construct(
+        EntityManager $entityManager,
+        int $pageCount,
+        HalResponseFactory $responseFactory,
+        ResourceGenerator $resourceGenerator
+    ) {
+        $this->entityManager     = $entityManager;
+        $this->pageCount         = $pageCount;
+        $this->responseFactory   = $responseFactory;
+        $this->resourceGenerator = $resourceGenerator;
+    }
+
+    public function handle(ServerRequestInterface $request) : ResponseInterface
+    {
+        $repository = $this->entityManager->getRepository(Album::class);
+
+        $query = $repository
+            ->createQueryBuilder('c')
+            ->getQuery();
+        $query->setMaxResults($this->pageCount);
+
+        $paginator = new AlbumCollection($query);
+        $resource  = $this->resourceGenerator->fromObject($paginator, $request);
+        return $this->responseFactory->createResponse($request, $resource);
+    }
+}
+```
+
+And another handler for displaying an individual album:
+
+```php
+declare(strict_types=1);
+
+namespace Album\Handler;
+
+use Album\Entity\Album;
+use Doctrine\ORM\EntityManager;
+use Zend\Expressive\Helper\ServerUrlHelper;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class ShowAlbumHandler implements RequestHandlerInterface
+{
+    protected $entityManager;
+    protected $urlHelper;
+
+    /**
+     * AnnouncementsViewHandler constructor.
+     * @param EntityManager $entityManager
+     * @param ServerUrlHelper $urlHelper
+     */
+    public function __construct(
+        EntityManager $entityManager,
+    ) {
+        $this->entityManager = $entityManager;
+    }
+
+    /**
+     * @param ServerRequestInterface $request
+     * @return ResponseInterface
+     */
+    public function handle(ServerRequestInterface $request) : ResponseInterface
+    {
+        $entityRepository = $this->entityManager->getRepository(Album::class);
+
+        $result = $entityRepository->find($request->getAttribute('id'));
+
+        if (empty($return)) {
+            throw new RuntimeException('Not Found', 404);
+        }
+
+        $resource = $this->resourceGenerator->fromObject($result, $request);
+        return $this->responseFactory->createResponse($request, $resource);
+    }
+}
+```
+
+In the above example, we map our `Album` entity such that:
+
+- it is route-based; we will generate relational links to such entities based on
+  existing routing definitions. (In this example, "albums.show".)
+- it uses the `ReflectionHydrator` from the [zend-hydrator
+  package](https://docs.zendframework.com/zend-hydrator) to extract a
+  representation of the object to use with HAL.
+
+For our `AlbumCollection`, we define it such that:
+
+- it, too, is route-based. (In this example, it maps to the route
+  "albums.list".)
+- the collection will map to the property "album".
+
+Since these mappings are in place, our handlers need only use the Doctrine
+`EntityManager` in order to retrieve the appropriate repository, and from there
+either retrieve appropriate entities (in the case of the `ShowAlbumHandler`), or
+seed a collection paginator (in the case of the `ListAlbumsHandler`). These
+values are known by the metadata map, and, as such, we can generate HAL
+resources for them without needing any other information.
+
+## Example: Doctrine Collections
+
+Sometimes we will want to return an entire collection at once. The `getResult()`
+method of `Doctrine\ORM\Query` will return an array of results by default, with
+each item in the array an object based on provided mappings.
+
+zend-expressive-hal will not work with arrays by default, as it needs a typed
+object in order to appropriately map it to a representation. To accomplish this,
+then, we have several options:
+
+- Create a custom extension of an SPL iterator such as `ArrayIterator` to wrap
+  the results.
+- Create a custom extension of something like `Doctrine\Common\Collections\ArrayCollection`
+  to wrap the results.
+
+The following examples are based on the paginated collection from above;
+familiarize yourself with that code before continuing.
+
+The first change we will make is to modify our `AlbumCollection` to extend the
+Doctrine `ArrayCollection`, instead of its `Paginator`:
+
+```php
+namespace Album\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+class AlbumCollection extends ArrayCollection
+{
+}
+```
+
+The only other changes we then need to make are to our `ListAlbumsHandler`:
+
+```php
+    public function handle(ServerRequestInterface $request) : ResponseInterface
+    {
+        $repository = $this->entityManager->getRepository(Album::class);
+
+        // Note that this removes the call to setMaxResults()
+        $query = $repository
+            ->createQueryBuilder('c')
+            ->getQuery();
+
+        // Note that we pass the collection class the query result, and not the
+        // query instance:
+        $collection = new AlbumCollection($query->getResult());
+
+        $resource  = $this->resourceGenerator->fromObject($collection, $request);
+        return $this->responseFactory->createResponse($request, $resource);
+    }
+```
+
+With these in place, we will now get representation of all items returned by the
+query.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 docs_dir: docs/book
 site_dir: docs/html
 pages:
-    - index.md
+    - Home: index.md
     - Introduction: intro.md
     - Reference:
       - "HAL": hal.md
@@ -9,6 +9,7 @@ pages:
       - "Generating Resources": resource-generator.md
       - "Custom Resources": cookbook/generating-custom-resources.md
       - "Representations": representations.md
+      - "Generating HAL for Doctrine Entities": doctrine.md
       - "Factories": factories.md
     - Cookbook:
         - "Generating Custom Links In Middleware and Request Handlers": cookbook/generating-custom-links-in-middleware.md
@@ -16,4 +17,4 @@ pages:
 site_name: zend-expressive-hal
 site_description: 'Hypertext Application Language for PSR-7 Applications'
 repo_url: 'https://github.com/zendframework/zend-expressive-hal'
-copyright: 'Copyright (c) 2017-2018 <a href="http://www.zend.com/">Zend Technologies USA Inc.</a>'
+copyright: 'Copyright (c) 2017-2019 <a href="http://www.zend.com/">Zend Technologies USA Inc.</a>'

--- a/src/ResourceGenerator/ExtractCollectionTrait.php
+++ b/src/ResourceGenerator/ExtractCollectionTrait.php
@@ -79,56 +79,20 @@ trait ExtractCollectionTrait
         ResourceGenerator $resourceGenerator,
         ServerRequestInterface $request
     ) : HalResource {
-        $data  = ['_total_items' => $collection->getTotalItemCount()];
-        $links = [];
+        $data      = ['_total_items' => $collection->getTotalItemCount()];
+        $pageCount = $collection->count();
 
-        $paginationParamType = $metadata->getPaginationParamType();
-        if (in_array($paginationParamType, $this->paginationTypes, true)) {
-            // Supports pagination
-            $pageCount = $collection->count();
-
-            $paginationParam = $metadata->getPaginationParam();
-            $page = $paginationParamType === AbstractCollectionMetadata::TYPE_QUERY
-                ? (int) ($request->getQueryParams()[$paginationParam] ?? 1)
-                : (int) $request->getAttribute($paginationParam, 1);
-
-            if ($page < 1 || ($page > $pageCount && $pageCount > 0)) {
-                throw new Exception\OutOfBoundsException(sprintf(
-                    'Page %d is out of bounds. Collection has %d page%s.',
-                    $page,
-                    $pageCount,
-                    $pageCount > 1 ? 's' : ''
-                ));
-            }
-
-            $collection->setCurrentPageNumber($page);
-
-            $links[] = $this->generateLinkForPage('self', $page, $metadata, $resourceGenerator, $request);
-            if ($page > 1) {
-                $links[] = $this->generateLinkForPage('first', 1, $metadata, $resourceGenerator, $request);
-                $links[] = $this->generateLinkForPage('prev', $page - 1, $metadata, $resourceGenerator, $request);
-            }
-            if ($page < $pageCount) {
-                $links[] = $this->generateLinkForPage('next', $page + 1, $metadata, $resourceGenerator, $request);
-                $links[] = $this->generateLinkForPage('last', $pageCount, $metadata, $resourceGenerator, $request);
-            }
-
-            $data['_page'] = $page;
-            $data['_page_count'] = $pageCount;
-        }
-
-        if (empty($links)) {
-            $links[] = $this->generateSelfLink($metadata, $resourceGenerator, $request);
-        }
-
-        $resources = [];
-        foreach ($collection as $item) {
-            $resources[] = $resourceGenerator->fromObject($item, $request);
-        }
-
-        return new HalResource($data, $links, [
-            $metadata->getCollectionRelation() => $resources,
-        ]);
+        return $this->createPaginatedCollectionResource(
+            $pageCount,
+            $data,
+            function (int $page) use ($collection) {
+                $collection->setCurrentPageNumber($page);
+            },
+            $collection,
+            $metadata,
+            $resourceGenerator,
+            $request
+        );
     }
 
     /**
@@ -150,52 +114,18 @@ trait ExtractCollectionTrait
         $pageCount  = (int) ceil($totalItems / $perPage);
 
         $data  = ['_total_items' => $totalItems];
-        $links = [];
 
-        $paginationParamType = $metadata->getPaginationParamType();
-        if (in_array($paginationParamType, $this->paginationTypes, true)) {
-            $paginationParam = $metadata->getPaginationParam();
-            $page = $paginationParamType === AbstractCollectionMetadata::TYPE_QUERY
-                ? (int) ($request->getQueryParams()[$paginationParam] ?? 1)
-                : (int) $request->getAttribute($paginationParam, 1);
-
-            if ($page < 1 || ($page > $pageCount && $pageCount > 0)) {
-                throw new Exception\OutOfBoundsException(sprintf(
-                    'Page %d is out of bounds. Collection has %d page%s.',
-                    $page,
-                    $pageCount,
-                    $pageCount > 1 ? 's' : ''
-                ));
-            }
-
-            $query->setFirstResult($pageCount * ($page - 1));
-
-            $links[] = $this->generateLinkForPage('self', $page, $metadata, $resourceGenerator, $request);
-            if ($page > 1) {
-                $links[] = $this->generateLinkForPage('first', 1, $metadata, $resourceGenerator, $request);
-                $links[] = $this->generateLinkForPage('prev', $page - 1, $metadata, $resourceGenerator, $request);
-            }
-            if ($page < $pageCount) {
-                $links[] = $this->generateLinkForPage('next', $page + 1, $metadata, $resourceGenerator, $request);
-                $links[] = $this->generateLinkForPage('last', $pageCount, $metadata, $resourceGenerator, $request);
-            }
-
-            $data['_page'] = $page;
-            $data['_page_count'] = $pageCount;
-        }
-
-        if (empty($links)) {
-            $links[] = $this->generateSelfLink($metadata, $resourceGenerator, $request);
-        }
-
-        $resources = [];
-        foreach ($collection as $item) {
-            $resources[] = $resourceGenerator->fromObject($item, $request);
-        }
-
-        return new HalResource($data, $links, [
-            $metadata->getCollectionRelation() => $resources,
-        ]);
+        return $this->createPaginatedCollectionResource(
+            $pageCount,
+            $data,
+            function (int $page) use ($query, $pageCount) {
+                $query->setFirstResult($pageCount * ($page - 1));
+            },
+            $collection,
+            $metadata,
+            $resourceGenerator,
+            $request
+        );
     }
 
     private function extractIterator(
@@ -219,6 +149,118 @@ trait ExtractCollectionTrait
             $resourceGenerator,
             $request
         )];
+
+        return new HalResource($data, $links, [
+            $metadata->getCollectionRelation() => $resources,
+        ]);
+    }
+
+    /**
+     * Create a collection resource representing a paginated set.
+     *
+     * Determines if the metadata uses a query or placeholder pagination type.
+     * If not, it generates a self relational link, and then immediately creates
+     * and returns a collection resource containing every item in the collection.
+     *
+     * If it does, it pulls the pagination parameter from the request using the
+     * appropriate source (query string arguments or routing parameter), and
+     * then checks to see if we have a valid page number, throwing an out of
+     * bounds exception if we do not. From the page, it then determines which
+     * relational pagination links to create, including a `self` relation,
+     * and aggregates the current page and total page count in the $data array
+     * before calling on createCollectionResource() to generate the final
+     * HAL resource instance.
+     *
+     * @param array<string, mixed> $data Data to render in the root of the HAL
+     *     resource.
+     * @param callable $notifyCollectionOfPage A callback that receives an integer
+     *     $page argument; this should be used to update the paginator instance
+     *     with the current page number.
+     */
+    private function createPaginatedCollectionResource(
+        int $pageCount,
+        array $data,
+        callable $notifyCollectionOfPage,
+        iterable $collection,
+        AbstractCollectionMetadata $metadata,
+        ResourceGenerator $resourceGenerator,
+        ServerRequestInterface $request
+    ) : HalResource {
+        $links               = [];
+        $paginationParamType = $metadata->getPaginationParamType();
+
+        if (! in_array($paginationParamType, $this->paginationTypes, true)) {
+            $links[] = $this->generateSelfLink($metadata, $resourceGenerator, $request);
+            return $this->createCollectionResource(
+                $links,
+                $data,
+                $collection,
+                $metadata,
+                $resourceGenerator,
+                $request
+            );
+        }
+
+        $paginationParam = $metadata->getPaginationParam();
+        $page = $paginationParamType === AbstractCollectionMetadata::TYPE_QUERY
+            ? (int) ($request->getQueryParams()[$paginationParam] ?? 1)
+            : (int) $request->getAttribute($paginationParam, 1);
+
+        if ($page < 1 || ($page > $pageCount && $pageCount > 0)) {
+            throw new Exception\OutOfBoundsException(sprintf(
+                'Page %d is out of bounds. Collection has %d page%s.',
+                $page,
+                $pageCount,
+                $pageCount > 1 ? 's' : ''
+            ));
+        }
+
+        $notifyCollectionOfPage($page);
+
+        $links[] = $this->generateLinkForPage('self', $page, $metadata, $resourceGenerator, $request);
+        if ($page > 1) {
+            $links[] = $this->generateLinkForPage('first', 1, $metadata, $resourceGenerator, $request);
+            $links[] = $this->generateLinkForPage('prev', $page - 1, $metadata, $resourceGenerator, $request);
+        }
+        if ($page < $pageCount) {
+            $links[] = $this->generateLinkForPage('next', $page + 1, $metadata, $resourceGenerator, $request);
+            $links[] = $this->generateLinkForPage('last', $pageCount, $metadata, $resourceGenerator, $request);
+        }
+
+        $data['_page'] = $page;
+        $data['_page_count'] = $pageCount;
+
+        return $this->createCollectionResource(
+            $links,
+            $data,
+            $collection,
+            $metadata,
+            $resourceGenerator,
+            $request
+        );
+    }
+
+    /**
+     * Create the collection resource with its embedded resources.
+     *
+     * Iterates the collection, passing each item to the resource generator
+     * to produce a HAL resource. These are then used to create an embedded
+     * relation in a master HAL resource that contains metadata around the
+     * collection itself (number of items, number of pages, etc.), and any
+     * relational links.
+     */
+    private function createCollectionResource(
+        array $links,
+        array $data,
+        iterable $collection,
+        AbstractCollectionMetadata $metadata,
+        ResourceGenerator $resourceGenerator,
+        ServerRequestInterface $request
+    ) : HalResource {
+        $resources = [];
+        foreach ($collection as $item) {
+            $resources[] = $resourceGenerator->fromObject($item, $request);
+        }
 
         return new HalResource($data, $links, [
             $metadata->getCollectionRelation() => $resources,

--- a/test/ResourceGenerator/DoctrinePaginatorTest.php
+++ b/test/ResourceGenerator/DoctrinePaginatorTest.php
@@ -1,0 +1,278 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-hal for the canonical source repository
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-hal/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Expressive\Hal\ResourceGenerator;
+
+use ArrayIterator;
+use Doctrine\ORM\AbstractQuery;
+use Doctrine\ORM\QueryBuilder;
+use Doctrine\ORM\Tools\Pagination\Paginator;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Psr\Http\Message\ServerRequestInterface;
+use Zend\Expressive\Hal\HalResource;
+use Zend\Expressive\Hal\Link;
+use Zend\Expressive\Hal\LinkGenerator;
+use Zend\Expressive\Hal\Metadata\RouteBasedCollectionMetadata;
+use Zend\Expressive\Hal\ResourceGenerator;
+use Zend\Expressive\Hal\ResourceGenerator\Exception\OutOfBoundsException;
+use Zend\Expressive\Hal\ResourceGenerator\RouteBasedCollectionStrategy;
+
+class DoctrinePaginatorTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->metadata      = $this->prophesize(RouteBasedCollectionMetadata::class);
+        $this->linkGenerator = $this->prophesize(LinkGenerator::class);
+        $this->generator     = $this->prophesize(ResourceGenerator::class);
+        $this->request       = $this->prophesize(ServerRequestInterface::class);
+        $this->paginator     = $this->prophesize(Paginator::class);
+
+        $this->strategy      = new RouteBasedCollectionStrategy();
+    }
+
+    public function mockQuery()
+    {
+        return $this->getMockBuilder(AbstractQuery::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getMaxResults', 'setFirstResult'])
+            ->getMockForAbstractClass();
+    }
+
+    public function mockLinkGeneration(string $relation, string $route, array $routeParams, array $queryStringArgs)
+    {
+        $link = $this->prophesize(Link::class)->reveal();
+        $this->linkGenerator
+            ->fromRoute(
+                $relation,
+                $this->request->reveal(),
+                $route,
+                $routeParams,
+                $queryStringArgs
+            )
+            ->willReturn($link);
+    }
+
+    public function invalidPageCombinations() : iterable
+    {
+        yield 'negative'   => [-1, 100];
+        yield 'zero'       => [0, 100];
+        yield 'too-high'   => [2, 1];
+    }
+
+    /**
+     * @dataProvider invalidPageCombinations
+     */
+    public function testThrowsOutOfBoundsExceptionForInvalidPage(int $page, int $numPages)
+    {
+        $query = $this->mockQuery();
+        $query->expects($this->once())
+            ->method('getMaxResults')
+            ->with()
+            ->willReturn(15);
+        $this->paginator->getQuery()->willReturn($query);
+        $this->paginator->count()->willReturn($numPages);
+
+        $this->metadata->getPaginationParamType()->willReturn(RouteBasedCollectionMetadata::TYPE_QUERY);
+        $this->metadata->getPaginationParam()->willReturn('page_num');
+        $this->request->getQueryParams()->willReturn(['page_num' => $page]);
+
+        $this->expectException(OutOfBoundsException::class);
+        $this->strategy->createResource(
+            $this->paginator->reveal(),
+            $this->metadata->reveal(),
+            $this->generator->reveal(),
+            $this->request->reveal()
+        );
+    }
+
+    public function testDoesNotCreateLinksForUnknownPaginationParamType()
+    {
+        $query = $this->mockQuery();
+        $query->expects($this->once())
+            ->method('getMaxResults')
+            ->with()
+            ->willReturn(15);
+        $this->paginator->getQuery()->willReturn($query);
+        $this->paginator->count()->willReturn(100);
+
+        $this->metadata->getPaginationParamType()->willReturn('unknown');
+        $this->metadata->getPaginationParam()->shouldNotBeCalled();
+        $this->metadata->getRouteParams()->willReturn([]);
+        $this->metadata->getQueryStringArguments()->willReturn([]);
+        $this->metadata->getRoute()->willReturn('test');
+        $this->metadata->getCollectionRelation()->willReturn('test');
+
+        $this->request
+            ->getQueryParams()
+            ->willReturn(['page' => 3])
+            ->shouldBeCalledTimes(1);
+        $this->request->getAttribute(Argument::any(), Argument::any())->shouldNotBeCalled();
+
+        $values = array_map(function ($value) {
+            return (object) ['value' => $value];
+        }, range(46, 60));
+        $this->paginator->getIterator()->willReturn(new ArrayIterator($values));
+
+        $testCase = $this;
+        foreach (range(46, 60) as $value) {
+            $this->generator
+                ->fromObject(
+                    (object) ['value' => $value],
+                    Argument::that([$this->request, 'reveal'])
+                )
+                ->will(function () use ($testCase) {
+                    $resource = $testCase->prophesize(HalResource::class);
+                    $resource->getElements()->willReturn(['test' => true]);
+                    return $resource->reveal();
+                })
+                ->shouldBeCalledTimes(1);
+        }
+        $this->generator->getLinkGenerator()->will([$this->linkGenerator, 'reveal']);
+
+        $this->mockLinkGeneration('self', 'test', [], ['page' => 3]);
+
+        $resource = $this->strategy->createResource(
+            $this->paginator->reveal(),
+            $this->metadata->reveal(),
+            $this->generator->reveal(),
+            $this->request->reveal()
+        );
+
+        $this->assertInstanceOf(HalResource::class, $resource);
+    }
+
+    public function testCreatesLinksForQueryBasedPagination()
+    {
+        $query = $this->mockQuery();
+        $query->expects($this->once())
+            ->method('getMaxResults')
+            ->with()
+            ->willReturn(15);
+        $this->paginator->getQuery()->willReturn($query);
+        $this->paginator->count()->willReturn(100);
+
+        $this->metadata->getPaginationParamType()->willReturn(RouteBasedCollectionMetadata::TYPE_QUERY);
+        $this->metadata->getPaginationParam()->willReturn('page_num');
+        $this->metadata->getRouteParams()->willReturn([]);
+        $this->metadata->getQueryStringArguments()->willReturn([]);
+        $this->metadata->getRoute()->willReturn('test');
+        $this->metadata->getCollectionRelation()->willReturn('test');
+
+        $this->request
+            ->getQueryParams()
+            ->willReturn(['page_num' => 3])
+            ->shouldBeCalledTimes(1);
+        $this->request->getAttribute(Argument::any(), Argument::any())->shouldNotBeCalled();
+
+        $values = array_map(function ($value) {
+            return (object) ['value' => $value];
+        }, range(46, 60));
+        $this->paginator->getIterator()->willReturn(new ArrayIterator($values));
+
+        $testCase = $this;
+        foreach (range(46, 60) as $value) {
+            $this->generator
+                ->fromObject(
+                    (object) ['value' => $value],
+                    Argument::that([$this->request, 'reveal'])
+                )
+                ->will(function () use ($testCase) {
+                    $resource = $testCase->prophesize(HalResource::class);
+                    $resource->getElements()->willReturn(['test' => true]);
+                    return $resource->reveal();
+                })
+                ->shouldBeCalledTimes(1);
+        }
+        $this->generator->getLinkGenerator()->will([$this->linkGenerator, 'reveal']);
+
+        $paginationLinks = [
+            'self'  => ['page_num' => 3],
+            'first' => ['page_num' => 1],
+            'prev'  => ['page_num' => 2],
+            'next'  => ['page_num' => 4],
+            'last'  => ['page_num' => 7],
+        ];
+        foreach ($paginationLinks as $relation => $queryStringArgs) {
+            $this->mockLinkGeneration($relation, 'test', [], $queryStringArgs);
+        }
+
+        $resource = $this->strategy->createResource(
+            $this->paginator->reveal(),
+            $this->metadata->reveal(),
+            $this->generator->reveal(),
+            $this->request->reveal()
+        );
+
+        $this->assertInstanceOf(HalResource::class, $resource);
+    }
+
+    public function testCreatesLinksForRouteBasedPagination()
+    {
+        $query = $this->mockQuery();
+        $query->expects($this->once())
+            ->method('getMaxResults')
+            ->with()
+            ->willReturn(15);
+        $this->paginator->getQuery()->willReturn($query);
+        $this->paginator->count()->willReturn(100);
+
+        $this->metadata->getPaginationParamType()->willReturn(RouteBasedCollectionMetadata::TYPE_PLACEHOLDER);
+        $this->metadata->getPaginationParam()->willReturn('page_num');
+        $this->metadata->getRouteParams()->willReturn([]);
+        $this->metadata->getQueryStringArguments()->willReturn([]);
+        $this->metadata->getRoute()->willReturn('test');
+        $this->metadata->getCollectionRelation()->willReturn('test');
+
+        $this->request->getQueryParams()->shouldNotBeCalled();
+        $this->request
+            ->getAttribute('page_num', 1)
+            ->willReturn(3)
+            ->shouldBeCalledTimes(1);
+
+        $values = array_map(function ($value) {
+            return (object) ['value' => $value];
+        }, range(46, 60));
+        $this->paginator->getIterator()->willReturn(new ArrayIterator($values));
+
+        $testCase = $this;
+        foreach (range(46, 60) as $value) {
+            $this->generator
+                ->fromObject(
+                    (object) ['value' => $value],
+                    Argument::that([$this->request, 'reveal'])
+                )
+                ->will(function () use ($testCase) {
+                    $resource = $testCase->prophesize(HalResource::class);
+                    $resource->getElements()->willReturn(['test' => true]);
+                    return $resource->reveal();
+                })
+                ->shouldBeCalledTimes(1);
+        }
+        $this->generator->getLinkGenerator()->will([$this->linkGenerator, 'reveal']);
+
+        $paginationLinks = [
+            'self'  => ['page_num' => 3],
+            'first' => ['page_num' => 1],
+            'prev'  => ['page_num' => 2],
+            'next'  => ['page_num' => 4],
+            'last'  => ['page_num' => 7],
+        ];
+        foreach ($paginationLinks as $relation => $routeParams) {
+            $this->mockLinkGeneration($relation, 'test', $routeParams, []);
+        }
+
+        $resource = $this->strategy->createResource(
+            $this->paginator->reveal(),
+            $this->metadata->reveal(),
+            $this->generator->reveal(),
+            $this->request->reveal()
+        );
+
+        $this->assertInstanceOf(HalResource::class, $resource);
+    }
+}


### PR DESCRIPTION
This patch provides updates to the `ExtractCollectionTrait` to allow identifying `Doctrine\ORM\Tools\Pagination\Paginator` instances and providing paginated HAL collection representations. It also documents how to provide HAL representations for both Doctrine entities and either paginated or non-paginated collections.