### PR TITLE
Fixes offset calculation for paginated Doctrine collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 Versions prior to 0.4.0 were released as the package "weierophinney/hal".
 
-## 1.3.1 - TBD
+## 1.3.1 - 2019-02-11
 
 ### Added
 
@@ -24,7 +24,7 @@ Versions prior to 0.4.0 were released as the package "weierophinney/hal".
 
 ### Fixed
 
-- Nothing.
+- [#56](https://github.com/zendframework/zend-expressive-hal/pull/56) fixes an issue calculating the offset when generating a paginated Doctrine collection.
 
 ## 1.3.0 - 2019-02-06
 

--- a/docs/book/doctrine.md
+++ b/docs/book/doctrine.md
@@ -365,6 +365,16 @@ seed a collection paginator (in the case of the `ListAlbumsHandler`). These
 values are known by the metadata map, and, as such, we can generate HAL
 resources for them without needing any other information.
 
+> ### Setting the offset
+>
+> When you plan to use paginated Doctrine result sets, you DO NOT need to
+> call `$query->setFirstResult()`. This will be called when generating the
+> result set based on the current page and the value of
+> `$query->getMaxResults()`.
+>
+> You MUST call `$query->setMaxResults()` prior to generating your resource if
+> you want it to be paginated, however.
+
 ## Example: Doctrine Collections
 
 Sometimes we will want to return an entire collection at once. The `getResult()`

--- a/src/ResourceGenerator/ExtractCollectionTrait.php
+++ b/src/ResourceGenerator/ExtractCollectionTrait.php
@@ -118,8 +118,8 @@ trait ExtractCollectionTrait
         return $this->createPaginatedCollectionResource(
             $pageCount,
             $data,
-            function (int $page) use ($query, $pageCount) {
-                $query->setFirstResult($pageCount * ($page - 1));
+            function (int $page) use ($query, $perPage) {
+                $query->setFirstResult($perPage * ($page - 1));
             },
             $collection,
             $metadata,

--- a/test/ResourceGenerator/DoctrinePaginatorTest.php
+++ b/test/ResourceGenerator/DoctrinePaginatorTest.php
@@ -153,6 +153,9 @@ class DoctrinePaginatorTest extends TestCase
             ->method('getMaxResults')
             ->with()
             ->willReturn(15);
+        $query->expects($this->once())
+            ->method('setFirstResult')
+            ->with(30);
         $this->paginator->getQuery()->willReturn($query);
         $this->paginator->count()->willReturn(100);
 
@@ -218,6 +221,9 @@ class DoctrinePaginatorTest extends TestCase
             ->method('getMaxResults')
             ->with()
             ->willReturn(15);
+        $query->expects($this->once())
+            ->method('setFirstResult')
+            ->with(30);
         $this->paginator->getQuery()->willReturn($query);
         $this->paginator->count()->willReturn(100);
 


### PR DESCRIPTION
The code was erroneously using the calculated `$pageCount`, which represented the total number of pages in the collection, instead of the `$perPage` value when calculating the result offset. This was due to missing assertions in the unit tests. The assertions have been added, and the code corrected accordingly.