### PR TITLE
Unable to convert self-referring instances to resources

### DIFF
--- a/test/ResourceGenerator/ResourceWithSelfReferringInstanceTest.php
+++ b/test/ResourceGenerator/ResourceWithSelfReferringInstanceTest.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-hal for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-hal/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Expressive\Hal\ResourceGenerator;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Zend\Expressive\Hal\HalResource;
+use Zend\Expressive\Hal\Link;
+use Zend\Expressive\Hal\LinkGenerator;
+use Zend\Expressive\Hal\Metadata\MetadataMap;
+use Zend\Expressive\Hal\Metadata\RouteBasedCollectionMetadata;
+use Zend\Expressive\Hal\Metadata\RouteBasedResourceMetadata;
+use Zend\Expressive\Hal\ResourceGenerator;
+use ZendTest\Expressive\Hal\Assertions;
+use ZendTest\Expressive\Hal\TestAsset;
+
+class ResourceWithSelfReferringInstanceTest extends TestCase
+{
+    use Assertions;
+
+    public function testSelfReferringIsEmbeddedAsResource()
+    {
+        $parent = new TestAsset\FooBar;
+        $parent->id = 1234;
+        $parent->foo = 'FOO';
+        $parent->bar = $parent;
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+
+        $metadataMap = $this->createMetadataMap();
+        $hydrators = $this->createHydrators();
+        $linkGenerator = $this->createLinkGenerator($request);
+
+        $generator = new ResourceGenerator(
+            $metadataMap->reveal(),
+            $hydrators->reveal(),
+            $linkGenerator->reveal()
+        );
+
+        $generator->addStrategy(
+            RouteBasedResourceMetadata::class,
+            ResourceGenerator\RouteBasedResourceStrategy::class
+        );
+
+        $generator->addStrategy(
+            RouteBasedCollectionMetadata::class,
+            ResourceGenerator\RouteBasedCollectionStrategy::class
+        );
+
+        $resource = $generator->fromObject($parent, $request->reveal());
+        $this->assertInstanceOf(HalResource::class, $resource);
+
+        $childResource = $resource->getElement('bar');
+        $this->assertInstanceOf(HalResource::class, $childResource);
+        $this->assertSame($parent, $childResource);
+    }
+
+    public function createMetadataMap()
+    {
+        $metadataMap = $this->prophesize(MetadataMap::class);
+
+        $fooBarMetadata = new RouteBasedResourceMetadata(
+            TestAsset\FooBar::class,
+            'foo-bar',
+            self::getObjectPropertyHydratorClass()
+        );
+
+        $metadataMap->has(TestAsset\FooBar::class)->willReturn(true);
+        $metadataMap->get(TestAsset\FooBar::class)->willReturn($fooBarMetadata);
+
+        return $metadataMap;
+    }
+
+    public function createLinkGenerator($request)
+    {
+        $linkGenerator = $this->prophesize(LinkGenerator::class);
+
+        $linkGenerator
+            ->fromRoute(
+                'self',
+                $request->reveal(),
+                'foo-bar',
+                [ 'id' => 1234 ]
+            )
+            ->willReturn(new Link('self', '/api/foo-bar/1234'));
+
+        return $linkGenerator;
+    }
+
+    public function createHydrators()
+    {
+        $hydratorClass = self::getObjectPropertyHydratorClass();
+
+        $hydrators = $this->prophesize(ContainerInterface::class);
+        $hydrators->get($hydratorClass)->willReturn(new $hydratorClass());
+        return $hydrators;
+    }
+}


### PR DESCRIPTION
- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior.
  - [x] Detail the new, expected behavior.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [ ] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.

Imagine the following example:
```php
class Parent {
    /** @var Child[] */
    public $childs;
    public function addChild(Child $child) {
        $this->childs[] = $child;
        $child->parent = $this;
    }
}
class Child {
    /** @var Parent */
    public $parent;
}

$parent = new Parent();
$parent->addChild(new Child());
$parent->addChild(new Child());

$generator->fromObject($parent, $request);
// the call above will result in an error:
// Error : Maximum function nesting level of '256' reached, aborting!
```

Other examples:
[One-To-One, Bidirectional](https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/association-mapping.html#one-to-one-bidirectional)
[One-To-One, Self-referencing](https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/association-mapping.html#one-to-one-self-referencing)
[One-To-Many, Bidirectional](https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/association-mapping.html#one-to-many-bidirectional)
[One-To-Many, Self-referencing](https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/association-mapping.html#one-to-many-self-referencing)
[Many-To-Many, Bidirectional](https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/association-mapping.html#many-to-many-bidirectional)
[Many-To-Many, Self-referencing](https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/association-mapping.html#many-to-many-self-referencing)

The zfcampus/zf-hal component solved this issue by using a `$maxDepth` [property in metadata](https://github.com/zfcampus/zf-hal/blob/master/src/Metadata/Metadata.php#L119) which is then passed through [here](https://github.com/zfcampus/zf-hal/blob/master/src/Plugin/Hal.php#L647) and [here](https://github.com/zfcampus/zf-hal/blob/master/src/Plugin/Hal.php#L674).

Using this approach would result in a change of the `\Zend\Expressive\Hal\ResourceGenerator\StrategyInterface` interface which would be a BC break.

I would love if someone comes up with an alternate solution which will not break BC.